### PR TITLE
Add functionality to OCEX pallet to support proxy accounts and LinkedList like Storage for workers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4628,6 +4628,7 @@ dependencies = [
  "orml-traits",
  "pallet-balances",
  "pallet-substratee-registry",
+ "pallet-timestamp",
  "parity-scale-codec",
  "polkadex-primitives",
  "rustc-hex",

--- a/pallets/ocex/Cargo.toml
+++ b/pallets/ocex/Cargo.toml
@@ -25,6 +25,7 @@ orml-currencies = { git = "https://github.com/Polkadex-Substrate/open-runtime-mo
 orml-traits = { git = "https://github.com/Polkadex-Substrate/open-runtime-module-library.git", default-features = false }
 pallet-balances = {git = "https://github.com/paritytech/substrate", default-features = false }
 pallet-substratee-registry = {git = "https://github.com/Polkadex-Substrate/pallet-substratee-registry.git", default-features = false}
+timestamp= {git = "https://github.com/paritytech/substrate.git", package = "pallet-timestamp", version = "3.0.0", default-features = false}
 
 [dev-dependencies]
 sp-keyring = {  git = "https://github.com/paritytech/substrate", default-features = false }
@@ -45,6 +46,7 @@ std = [
     "orml-tokens/std",
     "orml-currencies/std",
     "pallet-balances/std",
-    "pallet-substratee-registry/std"
+    "pallet-substratee-registry/std",
+    "timestamp/std"
 ]
 runtime-benchmarks = ["frame-benchmarking"]

--- a/pallets/ocex/src/lib.rs
+++ b/pallets/ocex/src/lib.rs
@@ -18,19 +18,36 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use codec::{Decode, Encode};
 use frame_support::StorageMap;
 use frame_support::{
-    decl_error, decl_event, decl_module, dispatch::DispatchResult, ensure, traits::Get, PalletId,
+    decl_error, decl_event, decl_module, decl_storage, dispatch::DispatchResult, ensure,
+    traits::Get, PalletId,
 };
 use frame_system as system;
 use frame_system::ensure_signed;
 use orml_traits::{MultiCurrency, MultiCurrencyExtended};
-use polkadex_primitives::assets::AssetId;
 use sp_runtime::traits::AccountIdConversion;
 use sp_std::prelude::*;
-// pub(crate) type BalanceOf<T> = <T as orml_tokens::Config>::Balance;
 
+use polkadex_primitives::assets::AssetId;
 
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug)]
+pub struct LinkedAccount<AccountID> {
+    prev: AccountID,
+    next: Option<AccountID>,
+    proxies: Vec<AccountID>,
+}
+
+impl<AccountId: Default> Default for LinkedAccount<AccountId> {
+    fn default() -> Self {
+        LinkedAccount {
+            prev: AccountId::default(),
+            next: None,
+            proxies: vec![],
+        }
+    }
+}
 
 pub trait Config:
     system::Config + orml_tokens::Config + pallet_substratee_registry::Config
@@ -45,6 +62,7 @@ pub trait Config:
         CurrencyId = AssetId,
         Balance = Self::Balance,
     >;
+    type ProxyLimit: Get<usize>;
 }
 
 decl_event!(
@@ -55,6 +73,9 @@ decl_event!(
     {
         TokenDeposited(AssetId, AccountId, Balance),
         TokenWithdrawn(AssetId, AccountId, Balance),
+        MainAccountRegistered(AccountId),
+        ProxyAdded(AccountId,AccountId),
+        ProxyRemoved(AccountId,AccountId),
     }
 );
 
@@ -63,9 +84,19 @@ decl_event!(
 decl_error! {
     pub enum Error for Module<T: Config> {
         NotARegisteredEnclave,
+        AlreadyRegistered,
+        NotARegisteredMainAccount,
+        ProxyLimitReached
     }
 }
 
+decl_storage! {
+    trait Store for Module<T: Config> as OCEX {
+        pub FirstAccount: Option<T::AccountId> = None;
+        pub LastAccount: Option<T::AccountId> = None;
+        pub MainAccounts get(fn get_main_accounts): map hasher(blake2_128_concat) T::AccountId => LinkedAccount<T::AccountId>;
+    }
+}
 decl_module! {
     pub struct Module<T: Config> for enum Call where
     origin: T::Origin {
@@ -98,8 +129,38 @@ decl_module! {
         /// It helps to notify enclave about sender's intend to withdraw via on-chain
         #[weight = 10000]
         pub fn withdraw(origin, asset_id:  AssetId, to: T::AccountId,amount: T::Balance) -> DispatchResult{
-            let sender: T::AccountId = ensure_signed(origin)?;
+            let _: T::AccountId = ensure_signed(origin)?;
             Self::deposit_event(RawEvent::TokenWithdrawn(asset_id, to, amount));
+            Ok(())
+        }
+
+        /// Register MainAccount
+        #[weight = 10000]
+        pub fn register(origin) -> DispatchResult{
+            let sender: T::AccountId = ensure_signed(origin)?;
+            ensure!(!<MainAccounts<T>>::contains_key(&sender), Error::<T>::AlreadyRegistered);
+            Self::register_acc(sender.clone())?;
+            Self::deposit_event(RawEvent::MainAccountRegistered(sender));
+            Ok(())
+        }
+
+        /// Add Proxy
+        #[weight = 10000]
+        pub fn add_proxy(origin, proxy: T::AccountId) -> DispatchResult{
+            let sender: T::AccountId = ensure_signed(origin)?;
+            ensure!(<MainAccounts<T>>::contains_key(&sender), Error::<T>::NotARegisteredMainAccount);
+            Self::add_proxy_(sender.clone(),proxy.clone())?;
+            Self::deposit_event(RawEvent::ProxyAdded(sender,proxy));
+            Ok(())
+        }
+
+        /// Remove Proxy
+        #[weight = 10000]
+        pub fn remove_proxy(origin, proxy: T::AccountId) -> DispatchResult{
+            let sender: T::AccountId = ensure_signed(origin)?;
+            ensure!(<MainAccounts<T>>::contains_key(&sender), Error::<T>::NotARegisteredMainAccount);
+            Self::remove_proxy_(sender.clone(),proxy.clone())?;
+            Self::deposit_event(RawEvent::ProxyRemoved(sender,proxy));
             Ok(())
         }
 
@@ -107,9 +168,79 @@ decl_module! {
 }
 
 impl<T: Config> Module<T> {
+    // Note add_proxy doesn't check if given proxy is already registered
+    pub fn add_proxy_(main: T::AccountId, proxy: T::AccountId) -> Result<(), Error<T>> {
+        let mut acc: LinkedAccount<T::AccountId> = <MainAccounts<T>>::get(&main);
+        if acc.proxies.len() < T::ProxyLimit::get() {
+            acc.proxies.push(proxy);
+            <MainAccounts<T>>::insert(main, acc);
+        } else {
+            return Err(Error::<T>::ProxyLimitReached);
+        }
+        Ok(())
+    }
+
+    pub fn remove_proxy_(main: T::AccountId, proxy: T::AccountId) -> Result<(), Error<T>> {
+        let mut acc: LinkedAccount<T::AccountId> = <MainAccounts<T>>::get(&main);
+        for i in 0..T::ProxyLimit::get() {
+            match acc.proxies.get(i) {
+                None => {}
+                Some(registered_proxy) => {
+                    if registered_proxy.eq(&proxy) {
+                        acc.proxies.remove(i);
+                        break;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
     pub fn get_account() -> T::AccountId {
         T::OcexId::get().into_account()
     }
-}
 
-// TODO: Set genesis storage to have some balance for PDEX and DOT for alice and bob
+    pub fn register_acc(sender: T::AccountId) -> Result<(), Error<T>> {
+        match <FirstAccount<T>>::get() {
+            Some(_) => {
+                // Get current last account_id
+                let last_acc_option: Option<T::AccountId> = <LastAccount<T>>::get();
+                let last_acc: T::AccountId = last_acc_option.unwrap();
+                // Get current last account
+                // If first acc is defined then last acc must be there
+                let mut last: LinkedAccount<T::AccountId> = <MainAccounts<T>>::get(&last_acc);
+                // modify next of current last account to sender
+                last.next = Some(sender.clone());
+                // write back modified previous last account
+                <MainAccounts<T>>::insert(&last_acc, last);
+                // set sender to last account
+                <LastAccount<T>>::put(sender.clone());
+                // write sender's struct to LinkedAccount
+                <MainAccounts<T>>::insert(
+                    sender,
+                    LinkedAccount {
+                        prev: last_acc,
+                        next: None,
+                        proxies: vec![],
+                    },
+                );
+            }
+            None => {
+                // Set sender as first acc
+                <FirstAccount<T>>::put(sender.clone());
+                // Set sender as last acc as  there is only one acc
+                <LastAccount<T>>::put(sender.clone());
+                // Set the sender's acc details
+                <MainAccounts<T>>::insert(
+                    sender,
+                    LinkedAccount {
+                        prev: T::AccountId::default(),
+                        next: None,
+                        proxies: vec![],
+                    },
+                );
+            }
+        }
+        Ok(())
+    }
+}

--- a/pallets/ocex/src/mock.rs
+++ b/pallets/ocex/src/mock.rs
@@ -1,0 +1,191 @@
+// This file is part of Polkadex.
+
+// Copyright (C) 2020-2021 Polkadex oü.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+use crate as ocex_pallet;
+use frame_support::{ord_parameter_types, parameter_types};
+use frame_system::{EnsureSignedBy, SetCode};
+use orml_traits::parameter_type_with_key;
+use polkadex_primitives::assets::AssetId;
+use sp_core::H256;
+use sp_runtime::{
+    testing::Header,
+    traits::{BlakeTwo256, IdentityLookup},
+};
+use sp_runtime::traits::Zero;
+use sp_std::convert::From;
+use orml_currencies::BasicCurrencyAdapter;
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+frame_support::construct_runtime!(
+    pub enum Test where
+        Block = Block,
+        NodeBlock = Block,
+        UncheckedExtrinsic = UncheckedExtrinsic,
+    {
+        System: frame_system::{Pallet, Call, Storage, Event<T>},
+        Timestamp: timestamp::{Pallet, Call, Storage, Inherent},
+        Ocex: ocex_pallet::{Pallet, Call, Event<T>},
+        SubstrateeRegistry: pallet_substratee_registry::{Pallet, Call, Storage, Event<T>},
+        Currencies: orml_currencies::{Pallet, Call, Event<T>},
+        OrmlToken: orml_tokens::{Pallet, Call, Storage, Event<T>},
+        PalletBalances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+    }
+);
+
+pub type Balance = u128;
+
+parameter_types! {
+    pub const BlockHashCount: u64 = 250;
+}
+
+impl system::Config for Test {
+    type BaseCallFilter = ();
+    type BlockWeights = ();
+    type BlockLength = ();
+    type Origin = Origin;
+    type Call = Call;
+    type Index = u64;
+    type BlockNumber = u64;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = u64;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = ();
+    type BlockHashCount = BlockHashCount;
+    type DbWeight = ();
+    type Version = ();
+    type PalletInfo = PalletInfo;
+    type AccountData = pallet_balances::AccountData<u128>;
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+    type SS58Prefix = ();
+    type OnSetCode = ();
+}
+
+parameter_types! {
+    pub const ExistentialDeposit: u128 = 500;
+    pub const MaxLocks: u32 = 50;
+}
+
+impl pallet_balances::Config for Test {
+    type MaxLocks = MaxLocks;
+    /// The type for recording an account's balance.
+    type Balance = Balance;
+    /// The ubiquitous event type.
+    type Event = ();
+    type DustRemoval = ();
+    type ExistentialDeposit = ExistentialDeposit;
+    type AccountStore = frame_system::Pallet<Test>;
+    type WeightInfo = ();
+}
+
+parameter_types! {
+	pub const GetNativeCurrencyId: AssetId = AssetId::POLKADEX;
+}
+
+impl orml_currencies::Config for Test {
+    type Event = ();
+    type MultiCurrency = OrmlToken;
+    type NativeCurrency = AdaptedBasicCurrency;
+    type GetNativeCurrencyId = GetNativeCurrencyId;
+    type WeightInfo = ();
+}
+
+parameter_types! {
+    pub const TresuryAccount: u64 = 9;
+}
+
+parameter_types! {
+    pub const ProxyLimit: usize = 2; // Max sub-accounts per main account
+    pub const OcexModuleId: PalletId = PalletId(*b"polka/ex");
+    pub const OCEXGenesisAccount: PalletId = PalletId(*b"polka/ga");
+}
+impl Config for Test {
+    type Event = ();
+    type OcexId = OcexModuleId;
+    type GenesisAccount = OCEXGenesisAccount;
+    type Currency = Currencies;
+    type ProxyLimit = ProxyLimit;
+}
+
+pub type AdaptedBasicCurrency = BasicCurrencyAdapter<Test, PalletBalances, i128, u128>;
+
+parameter_types! {
+    pub TreasuryModuleAccount: u64 = 1;
+}
+
+parameter_type_with_key! {
+    pub ExistentialDeposits: |_currency_id: AssetId| -> Balance {
+        Zero::zero()
+    };
+}
+
+impl orml_tokens::Config for Test {
+    type Event = ();
+    type Balance = Balance;
+    type Amount = i128;
+    type CurrencyId = AssetId;
+    type WeightInfo = ();
+    type ExistentialDeposits = ExistentialDeposits;
+    type OnDust = orml_tokens::TransferDust<Test, TreasuryModuleAccount>;
+}
+
+parameter_types! {
+        pub const MinimumPeriod: u64 = 6000 / 2;
+}
+
+pub type Moment = u64;
+
+impl timestamp::Config for Test {
+    type Moment = Moment;
+    type OnTimestampSet = ();
+    type MinimumPeriod = MinimumPeriod;
+    type WeightInfo = ();
+}
+
+parameter_types! {
+    pub const MomentsPerDay: Moment = 86_400_000; // [ms/d]
+}
+
+/// added by SCS
+impl pallet_substratee_registry::Config for Test {
+    type Event = ();
+    type Currency = PalletBalances;
+    type MomentsPerDay = MomentsPerDay;
+}
+
+
+
+pub type PolkadexOcexPallet = Pallet<Test>;
+
+// Build test environment by setting the root `key` for the Genesis.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+    let storage = system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap();
+
+    let mut ext: sp_io::TestExternalities = storage.into();
+    ext.execute_with(|| System::set_block_number(1));
+    ext
+}

--- a/pallets/ocex/src/test.rs
+++ b/pallets/ocex/src/test.rs
@@ -37,18 +37,18 @@ fn test_register_account(){
         // Verify LastAccount Storage
         assert_eq!(<LastAccount<Test>>::get(), 3);
         // Verify Main Account Storage
-        let latest_linked_account: LinkedAccount<u64> = LinkedAccount{
+        let latest_linked_account: LinkedAccount<Test> = LinkedAccount{
             prev: new_account,
             next: None,
             proxies: vec![]
         };
-        let linked_account: LinkedAccount<u64> = LinkedAccount{
+        let linked_account: LinkedAccount<Test> = LinkedAccount{
             prev: gen_account,
             next: Some(new_account_two),
             proxies: vec![]
         };
-        let expected_linked_account_gen: LinkedAccount<u64> = LinkedAccount{
-            prev: 0,
+        let expected_linked_account_gen: LinkedAccount<Test> = LinkedAccount{
+            prev: gen_account,
             next: Some(new_account),
             proxies: vec![]
         };
@@ -79,7 +79,7 @@ fn test_add_proxy(){
         assert_ok!(PolkadexOcexPallet::add_proxy(Origin::signed(new_account), proxy_account_one));
         // TODO: Already registered Proxies can be registered multiple times
         //assert_ok!(PolkadexOcexPallet::add_proxy(Origin::signed(new_account), proxy_account_one));
-        let expected_linked_account: LinkedAccount<u64> = LinkedAccount{
+        let expected_linked_account: LinkedAccount<Test> = LinkedAccount{
             prev: gen_account,
             next: None,
             proxies: vec![3]
@@ -113,7 +113,7 @@ fn test_remove_proxy(){
         let proxy_account_one = 3;
         assert_ok!(PolkadexOcexPallet::add_proxy(Origin::signed(new_account), proxy_account_one));
         assert_ok!(PolkadexOcexPallet::remove_proxy(Origin::signed(new_account), proxy_account_one));
-        let expected_linked_account: LinkedAccount<u64> = LinkedAccount{
+        let expected_linked_account: LinkedAccount<Test> = LinkedAccount{
             prev: gen_account,
             next: None,
             proxies: vec![]

--- a/pallets/ocex/src/test.rs
+++ b/pallets/ocex/src/test.rs
@@ -1,0 +1,132 @@
+// // This file is part of Polkadex.
+//
+// // Copyright (C) 2020-2021 Polkadex oü.
+// // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+//
+// // This program is free software: you can redistribute it and/or modify
+// // it under the terms of the GNU General Public License as published by
+// // the Free Software Foundation, either version 3 of the License, or
+// // (at your option) any later version.
+//
+// // This program is distributed in the hope that it will be useful,
+// // but WITHOUT ANY WARRANTY; without even the implied warranty of
+// // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// // GNU General Public License for more details.
+//
+// // You should have received a copy of the GNU General Public License
+// // along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+use crate::mock::*;
+use frame_support::{assert_noop, assert_ok};
+
+use super::*;
+use orml_traits::MultiCurrency;
+use polkadex_primitives::assets::AssetId;
+use sp_core::H160;
+
+#[test]
+fn test_register_account(){
+    new_test_ext().execute_with(|| {
+        // Register new account
+        let new_account: u64 = 2;
+        let gen_account: u64 = PolkadexOcexPallet::get_genesis_acc();
+        assert_ok!(PolkadexOcexPallet::register(Origin::signed(new_account)));
+        let new_account_two: u64 = 3;
+        assert_ok!(PolkadexOcexPallet::register(Origin::signed(new_account_two)));
+
+        // Verify LastAccount Storage
+        assert_eq!(<LastAccount<Test>>::get(), 3);
+        // Verify Main Account Storage
+        let latest_linked_account: LinkedAccount<u64> = LinkedAccount{
+            prev: new_account,
+            next: None,
+            proxies: vec![]
+        };
+        let linked_account: LinkedAccount<u64> = LinkedAccount{
+            prev: gen_account,
+            next: Some(new_account_two),
+            proxies: vec![]
+        };
+        let expected_linked_account_gen: LinkedAccount<u64> = LinkedAccount{
+            prev: 0,
+            next: Some(new_account),
+            proxies: vec![]
+        };
+        assert_eq!(<MainAccounts<Test>>::get(new_account_two), latest_linked_account);
+        assert_eq!(<MainAccounts<Test>>::get(new_account), linked_account);
+        assert_eq!(<MainAccounts<Test>>::get(gen_account), expected_linked_account_gen);
+
+
+
+
+    });
+
+    // Test Errors
+    new_test_ext().execute_with(|| {
+        let new_account: u64 = 2;
+        assert_ok!(PolkadexOcexPallet::register(Origin::signed(new_account)));
+        assert_noop!(PolkadexOcexPallet::register(Origin::signed(2)), Error::<Test>::AlreadyRegistered);
+    });
+}
+
+#[test]
+fn test_add_proxy(){
+    new_test_ext().execute_with(|| {
+        let new_account: u64 = 2;
+        let gen_account: u64 = PolkadexOcexPallet::get_genesis_acc();
+        assert_ok!(PolkadexOcexPallet::register(Origin::signed(new_account)));
+        let proxy_account_one = 3;
+        assert_ok!(PolkadexOcexPallet::add_proxy(Origin::signed(new_account), proxy_account_one));
+        // TODO: Already registered Proxies can be registered multiple times
+        //assert_ok!(PolkadexOcexPallet::add_proxy(Origin::signed(new_account), proxy_account_one));
+        let expected_linked_account: LinkedAccount<u64> = LinkedAccount{
+            prev: gen_account,
+            next: None,
+            proxies: vec![3]
+        };
+        assert_eq!(<MainAccounts<Test>>::get(new_account), expected_linked_account);
+    });
+
+    // Test Errors
+    new_test_ext().execute_with(|| {
+        let new_account: u64 = 2;
+        assert_ok!(PolkadexOcexPallet::register(Origin::signed(new_account)));
+        let proxy_account_one = 3;
+        let proxy_account_two = 4;
+        let not_registered_account: u64 = 4;
+        assert_noop!(PolkadexOcexPallet::add_proxy(Origin::signed(not_registered_account), proxy_account_one), Error::<Test>::NotARegisteredMainAccount);
+        assert_ok!(PolkadexOcexPallet::add_proxy(Origin::signed(new_account), proxy_account_one));
+        assert_ok!(PolkadexOcexPallet::add_proxy(Origin::signed(new_account), proxy_account_two));
+
+        // Check proxy Limit
+        let proxy_account_three = 5;
+        assert_noop!(PolkadexOcexPallet::add_proxy(Origin::signed(new_account), proxy_account_three), Error::<Test>::ProxyLimitReached);
+    });
+}
+
+#[test]
+fn test_remove_proxy(){
+    new_test_ext().execute_with(|| {
+        let new_account: u64 = 2;
+        let gen_account: u64 = PolkadexOcexPallet::get_genesis_acc();
+        assert_ok!(PolkadexOcexPallet::register(Origin::signed(new_account)));
+        let proxy_account_one = 3;
+        assert_ok!(PolkadexOcexPallet::add_proxy(Origin::signed(new_account), proxy_account_one));
+        assert_ok!(PolkadexOcexPallet::remove_proxy(Origin::signed(new_account), proxy_account_one));
+        let expected_linked_account: LinkedAccount<u64> = LinkedAccount{
+            prev: gen_account,
+            next: None,
+            proxies: vec![]
+        };
+        assert_eq!(<MainAccounts<Test>>::get(new_account), expected_linked_account);
+    });
+
+    // Verify Errors
+    new_test_ext().execute_with(|| {
+        let new_account: u64 = 2;
+        let proxy_account_one = 3;
+        assert_ok!(PolkadexOcexPallet::register(Origin::signed(new_account)));
+        let not_registered_account: u64 = 4;
+        assert_noop!(PolkadexOcexPallet::remove_proxy(Origin::signed(not_registered_account), proxy_account_one), Error::<Test>::NotARegisteredMainAccount);
+    });
+}

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+    branches: "main",
+    repositoryUrl: "https://github.com/Polkadex-Substrate/Polkadex",
+    plugins: ['@semantic-release/commit-analyzer', '@semantic-release/release-notes-generator', '@semantic-release/github']
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -34,6 +34,7 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
 // A few exports that help ease life for downstream crates.
+use frame_benchmarking::frame_support::pallet_prelude::Get;
 pub use frame_support::{
     construct_runtime, parameter_types,
     traits::{EnsureOrigin, KeyOwnerProofSystem, Randomness},
@@ -155,6 +156,7 @@ const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 parameter_types! {
     pub const PolkadexTreasuryModuleId: PalletId = PalletId(*b"polka/tr");
     pub const OcexModuleId: PalletId = PalletId(*b"polka/ex");
+    pub const OCEXGenesisAccount: PalletId = PalletId(*b"polka/ga");
     pub const Version: RuntimeVersion = VERSION;
     pub const BlockHashCount: BlockNumber = 2400;
     /// We allow for 2 seconds of compute with a 6 second average block time.
@@ -453,6 +455,7 @@ parameter_types! {
 impl polkadex_ocex::Config for Runtime {
     type Event = Event;
     type OcexId = OcexModuleId;
+    type GenesisAccount = OCEXGenesisAccount;
     type Currency = Currencies;
     type ProxyLimit = ProxyLimit;
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -9,7 +9,8 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_std::prelude::*;
 
-use frame_system::{RawOrigin, Config};
+use codec::{Decode, Encode};
+use frame_system::{Config, RawOrigin};
 use orml_currencies::BasicCurrencyAdapter;
 use orml_traits::{parameter_type_with_key, MultiCurrencyExtended};
 use pallet_grandpa::fg_primitives;
@@ -21,36 +22,34 @@ use sp_runtime::traits::AccountIdConversion;
 use sp_runtime::traits::{
     AccountIdLookup, BlakeTwo256, Block as BlockT, IdentifyAccount, NumberFor, Verify, Zero,
 };
-use codec::{Encode, Decode};
 
+use frame_support::traits::InstanceFilter;
 use sp_runtime::{
     create_runtime_str, generic, impl_opaque_keys,
     transaction_validity::{TransactionSource, TransactionValidity},
     ApplyExtrinsicResult, MultiSignature,
 };
-use frame_support::{traits::InstanceFilter};
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
 // A few exports that help ease life for downstream crates.
 pub use frame_support::{
-    construct_runtime, parameter_types, RuntimeDebug,
+    construct_runtime, parameter_types,
     traits::{EnsureOrigin, KeyOwnerProofSystem, Randomness},
     weights::{
         constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
         IdentityFee, Weight,
     },
-    PalletId, StorageValue,
+    PalletId, RuntimeDebug, StorageValue,
 };
 pub use pallet_balances::Call as BalancesCall;
+pub use pallet_substratee_registry;
 pub use pallet_timestamp::Call as TimestampCall;
 use pallet_transaction_payment::CurrencyAdapter;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 pub use sp_runtime::{Perbill, Permill};
-pub use pallet_substratee_registry;
-
 
 /// An index to a block.
 pub type BlockNumber = u32;
@@ -288,14 +287,14 @@ impl pallet_sudo::Config for Runtime {
 }
 
 parameter_types! {
-	// One storage item; key size 32, value size 8; .
-	pub const ProxyDepositBase: Balance = 0;
-	// Additional storage item size of 33 bytes.
-	pub const ProxyDepositFactor: Balance = 0;
-	pub const MaxProxies: u16 = 5;
-	pub const AnnouncementDepositBase: Balance = 0;
-	pub const AnnouncementDepositFactor: Balance = 0;
-	pub const MaxPending: u16 = 32;
+    // One storage item; key size 32, value size 8; .
+    pub const ProxyDepositBase: Balance = 0;
+    // Additional storage item size of 33 bytes.
+    pub const ProxyDepositFactor: Balance = 0;
+    pub const MaxProxies: u16 = 5;
+    pub const AnnouncementDepositBase: Balance = 0;
+    pub const AnnouncementDepositFactor: Balance = 0;
+    pub const MaxPending: u16 = 32;
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug)]
@@ -304,16 +303,17 @@ pub enum ProxyType {
     NonTransfer,
 }
 
-impl Default for ProxyType { fn default() -> Self { Self::Any } }
+impl Default for ProxyType {
+    fn default() -> Self {
+        Self::Any
+    }
+}
 
 impl InstanceFilter<Call> for ProxyType {
     fn filter(&self, c: &Call) -> bool {
         match self {
             ProxyType::Any => true,
-            ProxyType::NonTransfer => !matches!(
-                c,
-                Call::Currencies(..)
-            ),
+            ProxyType::NonTransfer => !matches!(c, Call::Currencies(..)),
         }
     }
 
@@ -364,10 +364,10 @@ impl EnsureOrigin<Origin> for EnsureGovernance {
 }
 
 impl polkadex_fungible_assets::Config for Runtime {
-	type Event = Event;
-	type TreasuryAccountId = TreasuryAccountId;
-	type GovernanceOrigin = EnsureGovernance;
-	type NativeCurrency = BasicCurrencyAdapter<Runtime, Balances, Amount, BlockNumber>;
+    type Event = Event;
+    type TreasuryAccountId = TreasuryAccountId;
+    type GovernanceOrigin = EnsureGovernance;
+    type NativeCurrency = BasicCurrencyAdapter<Runtime, Balances, Amount, BlockNumber>;
 }
 
 parameter_types! {
@@ -437,7 +437,7 @@ impl orml_currencies::Config for Runtime {
 }
 
 parameter_types! {
-	pub const MomentsPerDay: Moment = 86_400_000; // [ms/d]
+    pub const MomentsPerDay: Moment = 86_400_000; // [ms/d]
 }
 
 /// added by SCS
@@ -447,10 +447,14 @@ impl pallet_substratee_registry::Config for Runtime {
     type MomentsPerDay = MomentsPerDay;
 }
 
+parameter_types! {
+    pub const ProxyLimit: usize = 10; // Max sub-accounts per main account
+}
 impl polkadex_ocex::Config for Runtime {
     type Event = Event;
     type OcexId = OcexModuleId;
     type Currency = Currencies;
+    type ProxyLimit = ProxyLimit;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -34,7 +34,7 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
 // A few exports that help ease life for downstream crates.
-use frame_benchmarking::frame_support::pallet_prelude::Get;
+
 pub use frame_support::{
     construct_runtime, parameter_types,
     traits::{EnsureOrigin, KeyOwnerProofSystem, Randomness},


### PR DESCRIPTION
Implements a LinkedList like Storage for easy retrieval of main accounts by worker

Reference:  https://github.com/Polkadex-Substrate/polkadexTEE-worker/issues/1#issuecomment-830595079

Additional Dispatchables 
- Add proxy
- Remove proxy