### PR TITLE
ORML tokens is not supposed to handle native currency

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -400,11 +400,9 @@ pub fn testnet_genesis(
         orml_vesting: OrmlVestingConfig { vesting: vec![] },
         orml_tokens: TokensConfig {
             endowed_accounts: vec![
-                (endowed_accounts[0].to_owned(), AssetId::POLKADEX, 1000000000000000000u128),
                 (endowed_accounts[0].to_owned(), AssetId::DOT, 1000000000000000000u128),
                 (endowed_accounts[0].to_owned(), AssetId::BTC, 1000000000000000000u128),
                 (endowed_accounts[0].to_owned(), AssetId::USD, 1000000000000000000u128),
-                (endowed_accounts[1].to_owned(), AssetId::POLKADEX, 1000000000000000000u128),
                 (endowed_accounts[1].to_owned(), AssetId::DOT, 1000000000000000000u128),
                 (endowed_accounts[1].to_owned(), AssetId::BTC, 1000000000000000000u128),
                 (endowed_accounts[1].to_owned(), AssetId::USD, 1000000000000000000u128),


### PR DESCRIPTION
The issue is resolved by quering `system.Accounts` instead of `balances.Accounts`.
The native/non-native currency routing was already implemented on `orml_currencies` and it's working correctly.

The reason why we thought it's not working is that we query `balances.Accounts` and it just returned 0.

To get the native currency token amount, we should use `system.Accounts`
To get the non-native currency token amount, we should use `tokens.Accounts`

In `orml_currencies`, there are three sudo functions and transfer/transfer_native_currency works properly
`updateBalance` is not working and I debugged it. At the end, it's calling the `balances.deposit_creating` correctly but not updating the balance. So there may be a problem in `pallet_balances`.
However, `updateBalance` sudo function is not necessary for mainnet so we can close this issue with this PR.
I will create a new issue (which is not necessary for mainnet) for `orml_currencies.updateBalance` function.

Any ideas?
@Gauthamastro @simonsso @zktony 

#336