### PR TITLE
Increment runtime version to trigger automatic runtime upgrade of testnet

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -126,8 +126,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 265,
-    impl_version: 1,
+    spec_version: 266,
+    impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,
 };


### PR DESCRIPTION
This should trigger automatic update of internal testnet soba-net. Automatic merge is enabled.