### PR TITLE
small fix in instruction (change "Set Session Key" to "Session Key")

### DIFF
--- a/docs/run-a-validator.md
+++ b/docs/run-a-validator.md
@@ -298,7 +298,7 @@ You can restart your node at this point.
 
 You need to tell the chain your Session keys by signing and submitting an extrinsic. This is what associates your validator with your Controller account.
 
-Go to [Staking > Account Actions](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fblockchain.polkadex.trade#/staking/actions), and click "Set Session Key" on the bonding account you generated earlier. Enter the output from `author_rotateKeys` in the field and click "Set Session Key".
+Go to [Staking > Account Actions](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fblockchain.polkadex.trade#/staking/actions), and click "Session Key" on the bonding account you generated earlier. Enter the output from `author_rotateKeys` in the field and click "Set Session Key".
 
 ![Set Session Key](./screenshots/session_key.png)
 


### PR DESCRIPTION
There is no button "Set Session Key" on the page https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fblockchain.polkadex.trade#/staking/actions
correct button name is "Session Key" as you can see on screenshot:
 https://github.com/Polkadex-Substrate/Polkadex/blob/main/docs/screenshots/stashes.png