### PR TITLE
Implementing benchmarks for OCEX pallet 

### DIFF
--- a/pallets/ocex/Cargo.toml
+++ b/pallets/ocex/Cargo.toml
@@ -52,3 +52,9 @@ std = [
 #TODO: [#435] Currently broken, will be fixed in different issue
 #runtime-benchmarks = ["frame-benchmarking/runtime-benchmarks"]
 try-runtime = ["frame-support/try-runtime"]
+
+runtime-benchmarks = [
+    "frame-benchmarking/runtime-benchmarks",
+    "sp-runtime/runtime-benchmarks",
+    "frame-system/runtime-benchmarks",
+]

--- a/pallets/ocex/src/benchmarking.rs
+++ b/pallets/ocex/src/benchmarking.rs
@@ -72,7 +72,9 @@ benchmarks! {
 		assert_ok!(OCEX::<T>::register_main_account(RawOrigin::Signed(caller.clone()).into(), main));
 	}: _(RawOrigin::Signed(caller), proxy)
 	verify{
-		// Query events or storage 
+		let proxy = account("proxy",0,0);
+		let caller: T::AccountId = account("caller", 0, 0); 
+		assert_last_event::<T>(MainAccountRegistered{main: caller, proxy: proxy}.into());
 	}
 
 	close_trading_pair{
@@ -93,7 +95,8 @@ benchmarks! {
 		);
 	}: _(RawOrigin::Root, base, quote) 
 	verify{
-		// Query events or storage 
+		let trading_pair = OCEX::<T>::trading_pairs(base, quote).unwrap();
+		assert_last_event::<T>(Event::ShutdownTradingPair{pair:trading_pair}.into());
 	}
 
 	open_trading_pair{
@@ -114,7 +117,8 @@ benchmarks! {
 		);
 	}: _(RawOrigin::Root, base, quote)
 	verify{
-		// Query event or storage
+		let trading_pair = OCEX::<T>::trading_pairs(base, quote).unwrap();
+		assert_last_event::<T>(Event::OpenTradingPair{pair:trading_pair}.into());
 	}
 
 	register_trading_pair{
@@ -128,18 +132,20 @@ benchmarks! {
 		let min_depth: u32 = 1_u32;
 	}: _(RawOrigin::Root, base, quote, min_trade_amount.into(), max_trade_amount.into(), min_order_qty.into(), max_order_qty.into(), max_spread.into(), min_depth.into())
 	verify{
-		// Query events or storage 
+		let trading_pair = OCEX::<T>::trading_pairs(base, quote).unwrap();
+		assert_last_event::<T>(Event::TradingPairRegistered{base, quote}.into());
 	} 
 	
 	deposit{
-		let caller = account("caller", 0, 0);
+		let caller: T::AccountId = account("caller", 0, 0);
 		let asset = AssetId::asset(10);
 		let amount = 100000000_u32;
 		create_asset::<T>();
 
-	}: _(RawOrigin::Signed(caller), asset, amount.into())
+	}: _(RawOrigin::Signed(caller.clone()), asset, amount.into())
 	verify{
-		// Query events or storage
+		let balance_amount: BalanceOf::<T> = amount.into();
+		assert_last_event::<T>(Event::DepositSuccessful{user: caller, asset: asset, amount: balance_amount}.into());
 	}
 
 	collect_fees{
@@ -148,12 +154,12 @@ benchmarks! {
 		let beneficiary = account("beneficiary",0,0);
 	}: _(RawOrigin::Signed(caller), snapshot_id, beneficiary)
 	verify{
-		// Query events or storage 
+		// TODO! this requires snapshot to be submiited 
 	}
 
 	shutdown{}:_(RawOrigin::Root)
 	verify{
-		// Query events or ingress messages
+		// TODO! this requires an assertion from ingress messages 
 	} 
 
 	withdraw{
@@ -162,15 +168,15 @@ benchmarks! {
 		let withdrawal_index: u32 = 2;
 	}: _(RawOrigin::Signed(caller), snapshot_id, withdrawal_index)
 	verify{
-		// Query events or storage
+		// TODO! this requires a snapshot that contains an active withdrawal index
 	}
 
 	register_enclave{
-		let caller = account("caller",0,0);
+		let caller: T::AccountId = account("caller",0,0);
 		let ias_report: Vec<u8> = vec![];
-	}: _(RawOrigin::Signed(caller), ias_report)
+	}: _(RawOrigin::Signed(caller.clone()), ias_report)
 	verify{
-		// Query events to make sure the report signature is verified and used
+		assert_last_event::<T>(Event::EnclaveRegistered(caller).into());
 	}
 
 

--- a/pallets/ocex/src/benchmarking.rs
+++ b/pallets/ocex/src/benchmarking.rs
@@ -21,6 +21,7 @@ use crate::*;
 use frame_benchmarking::{benchmarks, whitelisted_caller, account};
 use frame_system::RawOrigin;
 use sp_runtime::AccountId32;
+use crate::mock::Test;
 
 benchmarks! {
 	register_main_account{
@@ -30,6 +31,44 @@ benchmarks! {
 	verify {
 		// assert_eq!(Pallet::<T>::dummy(), Some(b.into()))
 	}
+
+	add_proxy_account{
+		let caller = account("caller", 0, 0); 
+		let proxy = account("proxy",0,0);
+	}: _(RawOrigin::Signed(caller), proxy)
+	verify{
+		// Query events or storage 
+	}
+
+	close_trading_pair{
+		let base: AssetId = AssetId::asset(10);
+		let quote: AssetId = AssetId::asset(20);
+	}: _(RawOrigin::Root, base, quote) 
+	verify{
+		// Query events or storage 
+	}
+
+	open_trading_pair{
+		let base: AssetId = AssetId::asset(10);
+		let quote: AssetId = AssetId::asset(20); 
+	}: _(RawOrigin::Root, base, quote)
+	verify{
+		// Query event or storage
+	}
+
+	/* register_trading_pair{
+		let base: AssetId = AssetId::asset(10);
+		let quote: AssetId = AssetId::asset(20);
+		let min_trade_amount: BalanceOf::<Test> = 100;
+		let max_trade_amount: BalanceOf::<Test> = 1000;
+		let min_order_qty: BalanceOf::<Test> = 100; 
+		let max_order_qty: BalanceOf::<Test> = 1000; 
+		let max_spread: BalanceOf::<Test> = 100; 
+		let min_depth: BalanceOf::<Test> = 1;
+	}: _(RawOrigin::Root, base, quote, min_trade_amount.into(), max_trade_amount.into(), min_order_qty.into(), max_order_qty.into(), max_spread.into(), min_depth.into())
+	verify{
+		// Query events or storage 
+	} */
 	/* accumulate_dummy {
 		let b in 1 .. 1000;
 		let caller: T::AccountId = whitelisted_caller();

--- a/pallets/ocex/src/benchmarking.rs
+++ b/pallets/ocex/src/benchmarking.rs
@@ -18,17 +18,19 @@
 #![cfg(feature = "runtime-benchmarks")]
 
 use crate::*;
-use frame_benchmarking::{benchmarks, whitelisted_caller};
+use frame_benchmarking::{benchmarks, whitelisted_caller, account};
 use frame_system::RawOrigin;
+use sp_runtime::AccountId32;
 
 benchmarks! {
-	set_dummy_benchmark {
-		let b in 1 .. 1000;
-	}: set_dummy(RawOrigin::Root, b.into())
+	register_main_account{
+		let caller = account("caller", 0, 0);
+		let proxy = account("proxy", 0, 0);
+	}: _(RawOrigin::Signed(caller), proxy)
 	verify {
-		assert_eq!(Pallet::<T>::dummy(), Some(b.into()))
+		// assert_eq!(Pallet::<T>::dummy(), Some(b.into()))
 	}
-	accumulate_dummy {
+	/* accumulate_dummy {
 		let b in 1 .. 1000;
 		let caller: T::AccountId = whitelisted_caller();
 	}: _(RawOrigin::Signed(caller), b.into())
@@ -41,8 +43,8 @@ benchmarks! {
 		}
 	}: {
 		m.sort();
-	}
+	} */
 
 
-	impl_benchmark_test_suite!(Pallet, crate::tests::new_test_ext(), crate::tests::Test)
+	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test)
 }

--- a/pallets/ocex/src/benchmarking.rs
+++ b/pallets/ocex/src/benchmarking.rs
@@ -26,7 +26,21 @@ use frame_support::assert_ok;
 use crate::Pallet as OCEX;
 use frame_system::EventRecord;
 use crate::Event::MainAccountRegistered;
+use sp_core::H256;
+use polkadex_primitives::snapshot::{EnclaveSnapshot};
+use polkadex_primitives::{WithdrawalLimit, AssetsLimit};
+use frame_support::bounded_vec;
+use codec::Decode;
 // use crate::mock::Assets;
+
+fn gen_signature<T: Config>() -> T::Signature{
+	let sig_base: [u8; 64] = [194, 86, 40, 181, 200, 12, 205, 254, 172, 88, 86, 216, 236, 4, 116, 67, 185, 40, 6, 107, 15, 12, 77, 115, 8, 67, 3, 209, 139, 154, 95, 53, 178, 228, 234, 214, 42, 86, 92, 170, 142, 42, 50, 238, 76, 208, 55, 118, 34, 59, 62, 159, 91, 212, 25, 79, 180, 242, 100, 113, 51, 156, 163, 139];
+	let sig_base_vec = sig_base.to_vec();
+	let signature = T::Signature::decode(
+		&mut sig_base_vec.as_ref(),
+	).unwrap();
+	return signature;
+}
 
 fn create_asset<T: Config>() {
 	let caller: T::AccountId = account("caller",0,0);
@@ -177,7 +191,23 @@ benchmarks! {
 	}: _(RawOrigin::Signed(caller.clone()), ias_report)
 	verify{
 		assert_last_event::<T>(Event::EnclaveRegistered(caller).into());
+		// TODO
 	}
+	submit_snapshot{
+		let caller = account("caller",0,0);
+		let mmr_root: H256 = H256::from_slice(&[210, 56, 200, 34, 238, 216, 179, 3, 145, 126, 70, 52, 246, 40, 114, 190, 67, 101, 64, 12, 96, 36, 91, 129, 237, 83, 237, 98, 171, 246, 205, 98]);
+		let mut snapshot = EnclaveSnapshot::<T::AccountId, BalanceOf::<T>, WithdrawalLimit, AssetsLimit>{
+			snapshot_number: 0,
+    		merkle_root: mmr_root,
+			withdrawals: bounded_vec![],
+    		fees: bounded_vec![],
+		};
+		let signature = gen_signature::<T>();
+	}: _(RawOrigin::Signed(caller), snapshot, signature)
+	verify{
+		// TODO! Query some events over here
+	} 
+
 
 
 	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test)

--- a/pallets/ocex/src/benchmarking.rs
+++ b/pallets/ocex/src/benchmarking.rs
@@ -24,6 +24,8 @@ use frame_system::{RawOrigin, Origin};
 use sp_runtime::AccountId32;
 use frame_support::assert_ok;
 use crate::Pallet as OCEX;
+use frame_system::EventRecord;
+use crate::Event::MainAccountRegistered;
 // use crate::mock::Assets;
 
 fn create_asset<T: Config>() {
@@ -44,14 +46,23 @@ fn create_asset<T: Config>() {
 		)
 	);
 }
+fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
+	let events = frame_system::Pallet::<T>::events();
+	let system_event: <T as frame_system::Config>::Event = generic_event.into();
+	// compare to the last event record
+	let EventRecord { event, .. } = &events[events.len() - 1];
+	assert_eq!(event, &system_event);
+}
 
 benchmarks! {
 	register_main_account{
-		let caller = account("caller", 0, 0);
-		let proxy = account("proxy", 0, 0);
-	}: _(RawOrigin::Signed(caller), proxy)
+		let caller: T::AccountId = account("caller", 0, 0);
+		let proxy: T::AccountId = account("proxy", 0, 0);
+	}: _(RawOrigin::Signed(caller.clone()), proxy.clone())
 	verify {
-		// assert_eq!(Pallet::<T>::dummy(), Some(b.into()))
+		let caller: T::AccountId = account("caller", 0, 0);
+		let proxy: T::AccountId = account("proxy", 0, 0);
+		assert_last_event::<T>(MainAccountRegistered{main:caller, proxy: proxy}.into());
 	}
 
 	add_proxy_account{


### PR DESCRIPTION
This PR adds benchmarks for the OCEX pallet 
Following Points to note: 
- This does not include benchmarks for submit_snapshot and withdrawal, I would like to take it up as a separate issue as this seems to take a lot of time. This will be addressed in #481 