### PR TITLE
weights for OCEX extrinsics and proper weight annotation

### DIFF
--- a/pallets/ocex/src/lib.rs
+++ b/pallets/ocex/src/lib.rs
@@ -35,6 +35,7 @@ pub use pallet::*;
 #[cfg(test)]
 mod tests;
 
+#[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 mod types;
 pub mod weights;
@@ -175,7 +176,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Registers a new account in orderbook
-		#[pallet::weight(10000)]
+		#[pallet::weight(<T as Config>::WeightInfo::register_main_account())]
 		pub fn register_main_account(origin: OriginFor<T>, proxy: T::AccountId) -> DispatchResult {
 			let main_account = ensure_signed(origin)?;
 			ensure!(
@@ -194,7 +195,7 @@ pub mod pallet {
 		}
 
 		/// Adds a proxy account to a pre-registered main acocunt
-		#[pallet::weight(10000)]
+		#[pallet::weight(<T as Config>::WeightInfo::add_proxy_account())]
 		pub fn add_proxy_account(origin: OriginFor<T>, proxy: T::AccountId) -> DispatchResult {
 			let main_account = ensure_signed(origin)?;
 			ensure!(<Accounts<T>>::contains_key(&main_account), Error::<T>::MainAccountNotFound);
@@ -217,7 +218,7 @@ pub mod pallet {
 		}
 
 		/// Registers a new trading pair
-		#[pallet::weight(10000)]
+		#[pallet::weight(<T as Config>::WeightInfo::register_trading_pair())]
 		pub fn register_trading_pair(
 			origin: OriginFor<T>,
 			base: AssetId,
@@ -274,7 +275,7 @@ pub mod pallet {
 		}
 
 		/// Deposit Assets to Orderbook
-		#[pallet::weight(10000)]
+		#[pallet::weight(<T as Config>::WeightInfo::deposit())]
 		pub fn deposit(
 			origin: OriginFor<T>,
 			base: AssetId,
@@ -303,7 +304,7 @@ pub mod pallet {
 		}
 
 		/// Extrinsic used by enclave to submit balance snapshot and withdrawal requests
-		#[pallet::weight(10000)]
+		#[pallet::weight(<T as Config>::WeightInfo::submit_snapshot())]
 		pub fn submit_snapshot(
 			origin: OriginFor<T>,
 			base: AssetId,
@@ -349,7 +350,7 @@ pub mod pallet {
 		}
 
 		/// Extrinsic used to emit a shutdown request of an Enclave
-		#[pallet::weight(10000)]
+		#[pallet::weight(<T as Config>::WeightInfo::shutdown_enclave())]
 		pub fn shutdown_enclave(
 			origin: OriginFor<T>,
 			base: AssetId,
@@ -391,7 +392,7 @@ pub mod pallet {
 		}
 
 		/// In order to register itself - enclave must send it's own report to this extrinsic
-		#[pallet::weight(0 + T::DbWeight::get().writes(1))]
+		#[pallet::weight(<T as Config>::WeightInfo::register_enclave())]
 		pub fn register_enclave(origin: OriginFor<T>, ias_report: Vec<u8>) -> DispatchResult {
 			let _relayer = ensure_signed(origin)?;
 

--- a/pallets/ocex/src/weights.rs
+++ b/pallets/ocex/src/weights.rs
@@ -54,48 +54,102 @@ use sp_std::marker::PhantomData;
 
 /// Weight functions needed for pallet_example_basic.
 pub trait WeightInfo {
-	fn set_dummy_benchmark(b: u32, ) -> Weight;
-	fn accumulate_dummy(b: u32, ) -> Weight;
-	fn sort_vector(x: u32, ) -> Weight;
+	fn register_main_account() -> Weight;	
+	fn add_proxy_account() -> Weight;
+	fn register_trading_pair() -> Weight;
+	fn deposit() -> Weight;
+	fn submit_snapshot() -> Weight;
+	fn shutdown_enclave() -> Weight;
+	fn register_enclave() -> Weight;
 }
 
 /// Weights for pallet_example_basic using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-	fn set_dummy_benchmark(b: u32, ) -> Weight {
-		(5_834_000 as Weight)
-			.saturating_add((24_000 as Weight).saturating_mul(b as Weight))
+	fn register_main_account() -> Weight {
+		(18_098_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+	}
+
+	fn add_proxy_account() -> Weight {
+		(28_098_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+	}
+
+	fn register_trading_pair() -> Weight {
+		(16_010_093 as Weight)
+			.saturating_add(T::DbWeight::get().reads(3 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+	}
+
+	fn deposit() -> Weight {
+		(9_086_00 as Weight)
+			.saturating_add(T::DbWeight::get().reads(3 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
-	fn accumulate_dummy(b: u32, ) -> Weight {
-		(51_353_000 as Weight)
-			.saturating_add((14_000 as Weight).saturating_mul(b as Weight))
+
+	fn submit_snapshot() -> Weight {
+		(590_500_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(3 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+	}
+
+	fn shutdown_enclave() -> Weight {
+		(53_300_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(5 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+	}
+
+	fn register_enclave() -> Weight {
+		(1_969_500_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-	}
-	fn sort_vector(x: u32, ) -> Weight {
-		(2_569_000 as Weight)
-			// Standard Error: 0
-			.saturating_add((4_000 as Weight).saturating_mul(x as Weight))
 	}
 }
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
-	fn set_dummy_benchmark(b: u32, ) -> Weight {
-		(5_834_000 as Weight)
-			.saturating_add((24_000 as Weight).saturating_mul(b as Weight))
+	fn register_main_account() -> Weight {
+		(18_098_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
+	}
+
+	fn add_proxy_account() -> Weight {
+		(28_098_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
+	}
+
+	fn register_trading_pair() -> Weight {
+		(16_010_093 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(3 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
+	}
+
+	fn deposit() -> Weight {
+		(9_086_00 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(3 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
-	fn accumulate_dummy(b: u32, ) -> Weight {
-		(51_353_000 as Weight)
-			.saturating_add((14_000 as Weight).saturating_mul(b as Weight))
+
+	fn submit_snapshot() -> Weight {
+		(590_500_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(3 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
+	}
+
+	fn shutdown_enclave() -> Weight {
+		(53_300_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(5 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
+	}
+
+	fn register_enclave() -> Weight {
+		(1_969_500_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
-	}
-	fn sort_vector(x: u32, ) -> Weight {
-		(2_569_000 as Weight)
-			// Standard Error: 0
-			.saturating_add((4_000 as Weight).saturating_mul(x as Weight))
 	}
 }


### PR DESCRIPTION
* added Weight returning trait for OCEX pallet
* implemented above trait for runtime
* implemented above trait for tests and such
* annotated corresponding benchmarks with proper trait fetching
* all reads and wrights are included into weight calculations