### PR TITLE
unwrap replaced with safe unwrap_or_else

### DIFF
--- a/pallets/ocex/src/lib.rs
+++ b/pallets/ocex/src/lib.rs
@@ -616,7 +616,8 @@ pub mod pallet {
 			let iter = <RegisteredEnclaves<T>>::iter();
 			iter.for_each(|(enclave, attested_ts)| {
 				let current_timestamp = <timestamp::Pallet<T>>::get();
-				if current_timestamp.checked_sub(&attested_ts).unwrap() >= T::MsPerDay::get() {
+				// enclave will be removed even if something happens with substraction
+				if current_timestamp.checked_sub(&attested_ts).unwrap_or_else(|| current_timestamp) >= T::MsPerDay::get() {
 					enclaves_to_remove.push(enclave);
 				}
 			});


### PR DESCRIPTION
* Replaced `.unwrap()` to `unwrap_or_else()`
* Logic will make sure that on failure report will appear outdated as max possible timestamp will be used to compare against 24H long timeframe