### PR TITLE
Update deposit extrinsic 

### DIFF
--- a/pallets/ocex/src/lib.rs
+++ b/pallets/ocex/src/lib.rs
@@ -48,7 +48,7 @@ pub use weights::*;
 type BalanceOf<T> =
 	<<T as Config>::NativeCurrency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 
-const DEPOSIT_MAX: u128 = 1_000_000_000_000_000_000_000;
+const DEPOSIT_MAX: u128 = 1_000_000_000_000_000_000_000_000_000;
 
 // Definition of the pallet logic, to be aggregated at runtime definition through
 // `construct_runtime`.

--- a/pallets/ocex/src/lib.rs
+++ b/pallets/ocex/src/lib.rs
@@ -389,7 +389,7 @@ pub mod pallet {
 			Self::deposit_event(Event::TradingPairRegistered { base, quote });
 			Ok(())
 		}
-		// const DEPOSIT_MAX: u128 = 1_000_000_000_000_000_000_000;
+	
 		/// Deposit Assets to Orderbook
 		#[pallet::weight(<T as Config>::WeightInfo::deposit())]
 		pub fn deposit(
@@ -400,7 +400,7 @@ pub mod pallet {
 			let user = ensure_signed(origin)?;
 			// TODO: Check if asset is enabled for deposit
 
-			ensure!(amount.saturated_into::<u128>() < DEPOSIT_MAX, Error::<T>::DepositOverflow);
+			ensure!(amount.saturated_into::<u128>() <= DEPOSIT_MAX, Error::<T>::DepositOverflow);
 			let converted_amount =
 				Decimal::from(amount.saturated_into::<u128>()).div(Decimal::from(UNIT_BALANCE));
 

--- a/pallets/ocex/src/tests.rs
+++ b/pallets/ocex/src/tests.rs
@@ -438,23 +438,16 @@ fn test_deposit_assets_overflow() {
 			AssetId::polkadex,
 			1_000_000_000_000_000_000_000_000_000
 		));
-		let large_value: u128 = 999_999_999_999_999_999_999_999_999_9_u128;
+		let large_value: Decimal = Decimal::max_value();
 		mint_into_account_large(account_id.clone());
-		TotalAssets::<Test>::insert(AssetId::polkadex, Decimal::from_u128(large_value).unwrap());
+		// Directly setting the storage value, found it very difficult to manually fill it up 
+		TotalAssets::<Test>::insert(AssetId::polkadex, large_value.saturating_sub(Decimal::from_u128(1).unwrap()));
 	
-		for x in 0..1000{
-			assert_ok!(OCEX::deposit(
-				Origin::signed(account_id.clone().into()),
-				AssetId::polkadex,
-				1_000_000_000_000_000_000_000_000_000
-			));
-		}
 		assert_noop!(OCEX::deposit(
 			Origin::signed(account_id.clone().into()),
 			AssetId::polkadex,
-			1_000_000_000_000_000_000_000_000_000_0
+			10_u128.pow(20)
 		), Error::<Test>::DepositOverflow);
-
 	});
 }
 

--- a/pallets/ocex/src/tests.rs
+++ b/pallets/ocex/src/tests.rs
@@ -21,6 +21,7 @@ use frame_support::{
 	traits::{ConstU128, ConstU64, OnInitialize, OnTimestampSet},
 	PalletId,
 };
+use rust_decimal::prelude::FromPrimitive;
 use frame_system::EnsureRoot;
 use polkadex_primitives::{
 	assets::AssetId, ingress::IngressMessages, withdrawal::Withdrawal, Moment, Signature,
@@ -397,6 +398,63 @@ fn test_deposit() {
 		let event: IngressMessages<AccountId32> =
 			IngressMessages::Deposit(account_id, AssetId::polkadex, Decimal::new(10, 11));
 		assert_eq!(OCEX::ingress_messages()[0], event);
+	});
+}
+
+#[test]
+fn test_deposit_large_value() {
+	let account_id = create_account_id();
+	let custodian_account = OCEX::get_custodian_account();
+	new_test_ext().execute_with(|| {
+		mint_into_account_large(account_id.clone());
+		// Balances before deposit
+		assert_eq!(
+			<Test as Config>::NativeCurrency::free_balance(account_id.clone()),
+			1_000_000_000_000_000_000_000_000_000_000
+		);
+		assert_eq!(<Test as Config>::NativeCurrency::free_balance(custodian_account.clone()), 0);
+		assert_noop!(OCEX::deposit(
+			Origin::signed(account_id.clone().into()),
+			AssetId::polkadex,
+			1_000_000_000_000_000_000_000_000_0000
+		), Error::<Test>::DepositOverflow);
+	});
+}
+
+#[test]
+fn test_deposit_assets_overflow() {
+	let account_id = create_account_id();
+	let custodian_account = OCEX::get_custodian_account();
+	new_test_ext().execute_with(|| {
+		mint_into_account_large(account_id.clone());
+		// Balances before deposit
+		assert_eq!(
+			<Test as Config>::NativeCurrency::free_balance(account_id.clone()),
+			1_000_000_000_000_000_000_000_000_000_000
+		);
+		assert_eq!(<Test as Config>::NativeCurrency::free_balance(custodian_account.clone()), 0);
+		assert_ok!(OCEX::deposit(
+			Origin::signed(account_id.clone().into()),
+			AssetId::polkadex,
+			1_000_000_000_000_000_000_000_000_000
+		));
+		let large_value: u128 = 999_999_999_999_999_999_999_999_999_9_u128;
+		mint_into_account_large(account_id.clone());
+		TotalAssets::<Test>::insert(AssetId::polkadex, Decimal::from_u128(large_value).unwrap());
+	
+		for x in 0..1000{
+			assert_ok!(OCEX::deposit(
+				Origin::signed(account_id.clone().into()),
+				AssetId::polkadex,
+				1_000_000_000_000_000_000_000_000_000
+			));
+		}
+		assert_noop!(OCEX::deposit(
+			Origin::signed(account_id.clone().into()),
+			AssetId::polkadex,
+			1_000_000_000_000_000_000_000_000_000_0
+		), Error::<Test>::DepositOverflow);
+
 	});
 }
 
@@ -1047,6 +1105,10 @@ fn test_shutdown_bad_origin() {
 
 fn mint_into_account(account_id: AccountId32) {
 	Balances::deposit_creating(&account_id, 10000000000000000000000);
+}
+
+fn mint_into_account_large(account_id: AccountId32) {
+	Balances::deposit_creating(&account_id, 1_000_000_000_000_000_000_000_000_000_000);
 }
 
 fn create_asset_and_credit(asset_id: u128, account_id: AccountId32) {


### PR DESCRIPTION
So this PR has three changes 
1. Setting a constant value of 10^27 as MAX_DEPOSIT
2. Create a storage map with `assetid` and the value as `Decimal` 
3. The deposit extrinsic does a couple of checks with the said above 