### PR TITLE
fix: warnings and remove unused code

### DIFF
--- a/pallets/ocex/src/tests.rs
+++ b/pallets/ocex/src/tests.rs
@@ -1019,7 +1019,6 @@ fn test_onchain_events_overflow() {
 		> = BoundedBTreeMap::new();
 		withdrawal_map.try_insert(account_id.clone(), bounded_vec![withdrawal.clone()]).unwrap();
 		for x in account_id_vector.clone() {
-			let _withdrawal_500 = create_withdrawal_500::<Test>(x.clone());
 			withdrawal_map.try_insert(x, bounded_vec![withdrawal.clone()]).unwrap();
 		}
 
@@ -1065,7 +1064,6 @@ fn test_onchain_events_overflow() {
 
 #[test]
 fn test_withdrawal_bad_origin() {
-	let _account_id = create_account_id();
 	new_test_ext().execute_with(|| {
 		assert_noop!(OCEX::withdraw(Origin::root(), 1,), BadOrigin);
 

--- a/pallets/ocex/src/tests.rs
+++ b/pallets/ocex/src/tests.rs
@@ -1184,17 +1184,6 @@ pub fn create_withdrawal<T: Config>() -> Withdrawal<AccountId32> {
 	return withdrawal
 }
 
-pub fn create_withdrawal_500<T: Config>(account_id: AccountId32) -> Withdrawal<AccountId32> {
-	let withdrawal: Withdrawal<AccountId32> = Withdrawal {
-		main_account: account_id,
-		asset: AssetId::polkadex,
-		amount: 100_u32.into(),
-		event_id: 0,
-		fees: 1_u32.into(),
-	};
-	return withdrawal
-}
-
 pub fn create_fees<T: Config>() -> Fees {
 	let fees: Fees = Fees { asset: AssetId::polkadex, amount: Decimal::new(100, 1) };
 	return fees


### PR DESCRIPTION
This PR will fix all warnings in the `tests.rs` of `ocex` pallet 