### PR TITLE
Change order of assertion

### DIFF
--- a/pallets/asset-handler/src/lib.rs
+++ b/pallets/asset-handler/src/lib.rs
@@ -264,12 +264,15 @@ pub mod pallet {
 			rid: ResourceId,
 		) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
-			let destination_acc = T::AccountId::decode(&mut &destination_add[..])
-				.map_err(|_| Error::<T>::DestinationAddressNotValid)?;
+
 			ensure!(
 				chainbridge::Pallet::<T>::account_id() == sender,
 				Error::<T>::MinterMustBeRelayer
 			);
+
+			let destination_acc = T::AccountId::decode(&mut &destination_add[..])
+				.map_err(|_| Error::<T>::DestinationAddressNotValid)?;
+
 			let amount = Self::convert_18dec_to_12dec(amount)
 				.ok_or_else(|| Error::<T>::DivisionUnderflow)?;
 			T::AssetManager::mint_into(


### PR DESCRIPTION
The Pr fixes following things
- [x] While minting asset check condition of account must be a relayer  moved above then other calculations are performed.
Note: test case was already present