### PR TITLE
spec_name changed from default

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -110,7 +110,7 @@ pub fn wasm_binary_unwrap() -> &'static [u8] {
 
 /// Runtime version.
 pub const VERSION: RuntimeVersion = RuntimeVersion {
-	spec_name: create_runtime_str!("node"),
+	spec_name: create_runtime_str!("polkadex-node"),
 	impl_name: create_runtime_str!("polkadex-official"),
 	authoring_version: 10,
 	// Per convention: if the runtime behavior changes, increment spec_version


### PR DESCRIPTION
## Describe your changes
changed node's `spec_name` to `polkadex-node` to fix [this issue](https://github.com/polkadot-js/apps/issues/8261) with plokadot
## Issue ticket number and link
Closes #583 

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] I removed all Clippy and Formatting Warnings. 
- [x] I added required Copyrights.
