### PR TITLE
Asset handler tests improvement

### DIFF
--- a/pallets/asset-handler/src/lib.rs
+++ b/pallets/asset-handler/src/lib.rs
@@ -236,7 +236,7 @@ pub mod pallet {
 		// Thea Asset has not been registered
 		AssetNotRegistered,
 		// Identifier length provided is wrong
-		IdentifierLenghtMismatch,
+		IdentifierLengthMismatch,
 	}
 
 	#[pallet::hooks]
@@ -334,7 +334,7 @@ pub mod pallet {
 			// Check for index error
 			ensure!(
 				asset_identifier.len() >= identifier_length as usize,
-				Error::<T>::IdentifierLenghtMismatch
+				Error::<T>::IdentifierLengthMismatch
 			);
 
 			let mut derived_asset_id = vec![];

--- a/pallets/asset-handler/src/mock.rs
+++ b/pallets/asset-handler/src/mock.rs
@@ -27,7 +27,6 @@ use sp_runtime::{
 use crate::pallet as asset_handler;
 
 use frame_support::PalletId;
-use sp_runtime::traits::AccountIdConversion;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -157,7 +156,6 @@ impl asset_handler::Config for Test {
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	let _alice = 1u64;
-	let bridge_id: u64 = PalletId(*b"polka/bg").into_account_truncating();
 	let mut t = system::GenesisConfig::default().build_storage::<Test>().unwrap();
 	pallet_balances::GenesisConfig::<Test>::default()
 		.assimilate_storage(&mut t)

--- a/pallets/asset-handler/src/tests.rs
+++ b/pallets/asset-handler/src/tests.rs
@@ -15,7 +15,9 @@
 use frame_support::{assert_noop, assert_ok};
 use parity_scale_codec::Decode;
 use sp_core::{H160, U256};
-use sp_runtime::{BoundedBTreeSet, BoundedVec, DispatchError, DispatchError::BadOrigin, TokenError};
+use sp_runtime::{
+	BoundedBTreeSet, BoundedVec, DispatchError, DispatchError::BadOrigin, TokenError,
+};
 
 use crate::{
 	mock,
@@ -605,6 +607,12 @@ pub fn test_create_thea_asset() {
 }
 
 #[test]
+pub fn test_create_thea_asset_with_mismatching_identifier_will_return_identifier_length_mismatch_error(
+) {
+	// TODO: Implement
+}
+
+#[test]
 pub fn test_mint_thea_asset_with_unknown_recipient_will_return_cannot_create_error() {
 	let asset_address: H160 = ASSET_ADDRESS.parse().unwrap();
 	let asset_id = create_thea_asset_id(0, 5);
@@ -647,11 +655,6 @@ pub fn test_mint_thea_asset_with_zero_amount_will_return_amount_cannot_be_zero_e
 }
 
 #[test]
-pub fn test_create_thea_asset_with_mismatching_identifier_will_return_identifier_length_mismatch_error() {
-	// TODO: Implement
-}
-
-#[test]
 pub fn test_mint_thea_asset_will_increase_asset_balance() {
 	let asset_address: H160 = ASSET_ADDRESS.parse().unwrap();
 	let recipient = create_recipient_account();
@@ -659,8 +662,8 @@ pub fn test_mint_thea_asset_will_increase_asset_balance() {
 
 	new_test_ext().execute_with(|| {
 		assert_ok!(create_thea_asset(asset_address, 0, 5));
-		// TODO: Investigate why `mint_thea_asset` from the next line is returns `TokenError::CannotCreate`
-		//  with provided args which suppose to be valid
+		// FIXME: Investigate why `mint_thea_asset` from the next line is returns
+		//  `TokenError::CannotCreate`  with provided args which suppose to be valid
 		assert_ok!(AssetHandler::mint_thea_asset(asset_id, recipient, 100_u128));
 		assert_eq!(AssetHandler::account_balances(vec![asset_id], recipient)[0], 100_u128);
 	})
@@ -741,12 +744,16 @@ fn create_recipient_account() -> u64 {
 	<Test as frame_system::Config>::AccountId::decode(&mut &recipient[..]).unwrap()
 }
 
-fn create_thea_asset(asset_address: H160, network_id: u8, identifier_length: u8) -> Result<(), DispatchError> {
+fn create_thea_asset(
+	asset_address: H160,
+	network_id: u8,
+	identifier_length: u8,
+) -> Result<(), DispatchError> {
 	AssetHandler::create_thea_asset(
 		Origin::signed(1),
 		network_id,
 		identifier_length,
-		BoundedVec::try_from(asset_address.to_fixed_bytes().to_vec()).unwrap()
+		BoundedVec::try_from(asset_address.to_fixed_bytes().to_vec()).unwrap(),
 	)
 }
 

--- a/pallets/asset-handler/src/tests.rs
+++ b/pallets/asset-handler/src/tests.rs
@@ -81,8 +81,7 @@ pub fn test_create_asset_with_already_existed_asset_will_return_already_register
 
 #[test]
 pub fn test_mint_asset_with_invalid_resource_id() {
-	let (asset_address, relayer, recipient, recipient_account, chain_id, account) =
-		mint_asset_data();
+	let (asset_address, relayer, recipient, _, chain_id, account) = mint_asset_data();
 	new_test_ext().execute_with(|| {
 		allowlist_token(asset_address);
 		assert_ok!(AssetHandler::create_asset(
@@ -117,8 +116,7 @@ pub fn test_mint_asset_with_invalid_resource_id() {
 
 #[test]
 pub fn test_register_asset_twice_create_error() {
-	let (asset_address, relayer, recipient, recipient_account, chain_id, account) =
-		mint_asset_data();
+	let (asset_address, _, _, _, chain_id, account) = mint_asset_data();
 	new_test_ext().execute_with(|| {
 		allowlist_token(asset_address);
 		assert_ok!(AssetHandler::create_asset(
@@ -610,7 +608,13 @@ pub fn test_create_thea_asset() {
 #[test]
 pub fn test_create_thea_asset_with_mismatching_identifier_will_return_identifier_length_mismatch_error(
 ) {
-	// TODO: Implement
+	let asset_address: H160 = ASSET_ADDRESS.parse().unwrap();
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			create_thea_asset(asset_address, 0, 25),
+			Error::<Test>::IdentifierLengthMismatch
+		);
+	})
 }
 
 #[test]
@@ -663,8 +667,8 @@ pub fn test_mint_thea_asset_will_increase_asset_balance() {
 
 	new_test_ext().execute_with(|| {
 		assert_ok!(create_thea_asset(asset_address, 0, 5));
-		// FIXME: Investigate why `mint_thea_asset` from the next line is returns
-		//  `TokenError::CannotCreate`  with provided args which suppose to be valid
+		//recipient needs to have existential deposit
+		assert_ok!(Balances::set_balance(Origin::root(), recipient, 1 * UNIT_BALANCE, 0));
 		assert_ok!(AssetHandler::mint_thea_asset(asset_id, recipient, 100_u128));
 		assert_eq!(AssetHandler::account_balances(vec![asset_id], recipient)[0], 100_u128);
 	})


### PR DESCRIPTION
In this PR:
- Common implementation in  `thea` related tests  moved to separate private functions to be reused.
- Extended amount of tests to cover more cases
- Added functions with todo's inside for missing cases 