### PR TITLE
revert signing Payload struct

### DIFF
--- a/runtime/src/signedpayload.rs
+++ b/runtime/src/signedpayload.rs
@@ -9,14 +9,8 @@ use sp_std::vec::Vec;
 /// Note that the payload that we sign to produce unchecked extrinsic signature
 /// is going to be different than the `SignaturePayload` - so the thing the extrinsic
 /// actually contains.
-pub struct SignedPayload<Call, Extra: SignedExtension>(SignedPayloadInner<Call, Extra>);
+pub struct SignedPayload<Call, Extra: SignedExtension>((Call, Extra, Extra::AdditionalSigned));
 
-#[derive(Encode, Clone, Copy)]
-pub struct SignedPayloadInner<Call, Extra: SignedExtension> {
-	call: Call,
-	extra: Extra,
-	additional_signed: Extra::AdditionalSigned,
-}
 
 impl<Call, Extra> SignedPayload<Call, Extra>
 where
@@ -28,18 +22,18 @@ where
 	/// This function may fail if `additional_signed` of `Extra` is not available.
 	pub fn new(call: Call, extra: Extra) -> Result<Self, TransactionValidityError> {
 		let additional_signed = extra.additional_signed()?;
-		let raw_payload = Self(SignedPayloadInner { call, extra, additional_signed });
-		Ok(raw_payload)
+		let raw_payload = (call, extra, additional_signed);
+		Ok(Self(raw_payload))
 	}
 
 	/// Create new `SignedPayload` from raw components.
 	pub fn from_raw(call: Call, extra: Extra, additional_signed: Extra::AdditionalSigned) -> Self {
-		Self(SignedPayloadInner { call, extra, additional_signed })
+		Self((call, extra, additional_signed))
 	}
 
 	/// Deconstruct the payload into it's components.
 	pub fn deconstruct(self) -> (Call, Extra, Extra::AdditionalSigned) {
-		(self.0.call, self.0.extra, self.0.additional_signed)
+		self.0
 	}
 }
 
@@ -52,13 +46,17 @@ where
 	///
 	/// Payloads longer than 256 bytes are going to be `blake2_256`-hashed.
 	fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
-		let signature_scheme = parse_signature_scheme::<Extra>(&self.0.additional_signed);
+		let (_, _, additional_signed) = &self.0;
+		let signature_scheme = parse_signature_scheme::<Extra>(additional_signed);
 		self.0.using_encoded(|payload| {
+			// FIXME: Temporary Fix is to remove the
+			// last byte until https://github.com/polkadot-js/api/issues/5431 is resolved.
+			let payload_trimmed = &payload[0..payload.len()-1];
 			match signature_scheme {
 				// Ethereum like signing
-				1 => f(&ethereum_signing(payload)),
+				1 => f(&ethereum_signing(payload_trimmed)),
 				// Substrate Generic Signing
-				_ => f(&substrate_signing(payload)[..]),
+				_ => f(&substrate_signing(payload_trimmed)[..]),
 			}
 		})
 	}
@@ -72,9 +70,6 @@ where
 }
 
 pub fn substrate_signing(payload: &[u8]) -> Vec<u8> {
-	// FIXME: Temporary Fix is to remove the
-	// last byte until https://github.com/polkadot-js/api/issues/5431 is resolved.
-	let payload: &[u8] = &payload[0..payload.len()-2];
 	if payload.len() > 256 {
 		blake2_256(payload).to_vec()
 	} else {


### PR DESCRIPTION
chore: revert back struct for signed payload and trim last byte for all transactions before signature validation
Note this is temporary fix until  https://github.com/polkadot-js/api/issues/5431 is resolved.