### PR TITLE
Fix of tarpaulin legacy error in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: '0.22.0'
-          args: '--exclude polkadex-node node-polkadex-runtime --workspace --timeout 180'
+          args: '--avoid-cfg-tarpaulin --exclude polkadex-node node-polkadex-runtime --workspace --timeout 180'
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
Added tarpaulin CI flag to fix legacy error. [Here](https://github.com/xd009642/tarpaulin/blob/develop/README.md#ignoring-code-in-files) is an official doc.
