### PR TITLE
Thea Pallet: Set Rotation

### DIFF
--- a/pallets/thea-staking/src/lib.rs
+++ b/pallets/thea-staking/src/lib.rs
@@ -37,11 +37,11 @@ use thea_primitives::{
 	BLSPublicKey,
 };
 mod election;
-#[cfg(test)]
-mod mock;
+// #[cfg(test)]
+// mod mock;
 mod session;
-#[cfg(test)]
-mod tests;
+// #[cfg(test)]
+// mod tests;
 
 /// A type alias for the balance type from this pallet's point of view.
 pub type BalanceOf<T> = <T as pallet_balances::Config>::Balance;

--- a/pallets/thea-staking/src/lib.rs
+++ b/pallets/thea-staking/src/lib.rs
@@ -630,6 +630,13 @@ impl<T: Config> Pallet<T> {
 		(vec_of_bls_keys, account_ids)
 	}
 
+	pub fn get_queued_relayers_bls_keys(network: Network) -> Vec<BLSPublicKey> {
+		<QueuedRelayers<T>>::get(network)
+			.iter()
+			.map(|(_, b)| *b)
+			.collect::<Vec<BLSPublicKey>>()
+	}
+
 	pub fn compute_next_session(network: Network, expiring_session_index: SessionIndex) {
 		let session_in_consideration = expiring_session_index.saturating_add(2);
 		log::trace!(target: "runtime::thea::staking", "computing relayers of session {:?}", session_in_consideration);

--- a/pallets/thea-staking/src/lib.rs
+++ b/pallets/thea-staking/src/lib.rs
@@ -51,6 +51,7 @@ pub trait SessionChanged {
 	type Network;
 	type OnSessionChange;
 	fn on_new_session(map: BTreeMap<Self::Network, Self::OnSessionChange>);
+	fn set_new_networks(networks: sp_std::collections::btree_set::BTreeSet<Self::Network>);
 }
 // Definition of the pallet logic, to be aggregated at runtime definition through
 // `construct_runtime`.
@@ -101,6 +102,9 @@ pub mod pallet {
 			Network = Network,
 			OnSessionChange = OnSessionChange<Self::AccountId>,
 		>;
+
+		/// Governance origin to update the thea staking configuration
+		type GovernanceOrigin: EnsureOrigin<<Self as frame_system::Config>::Origin>;
 	}
 
 	// Simple declaration of the `Pallet` type. It is placeholder we use to implement traits and
@@ -256,6 +260,34 @@ pub mod pallet {
 			Self::deposit_event(Event::<T>::OutgoingCandidateAdded { candidate });
 			Ok(())
 		}
+
+		/// Adds a new network, it will also update the thea pallet's storage
+		///
+		/// # Parameters
+		///
+		/// `network`: Network identifier to add
+		#[pallet::call_index(7)]
+		#[pallet::weight(10000)]
+		pub fn add_network(origin: OriginFor<T>, network: Network) -> DispatchResult {
+			T::GovernanceOrigin::ensure_origin(origin)?;
+			Self::do_add_new_network(network);
+			Self::deposit_event(Event::<T>::NetworkAdded { network });
+			Ok(())
+		}
+
+		/// Removes a network, it will also update the thea pallet's storage
+		///
+		/// # Parameters
+		///
+		/// `network`: Network identifier to add
+		#[pallet::call_index(8)]
+		#[pallet::weight(10000)]
+		pub fn remove_network(origin: OriginFor<T>, network: Network) -> DispatchResult {
+			T::GovernanceOrigin::ensure_origin(origin)?;
+			Self::do_remove_network(network);
+			Self::deposit_event(Event::<T>::NetworkRemoved { network });
+			Ok(())
+		}
 	}
 
 	/// Events are a simple means of reporting specific conditions and
@@ -266,6 +298,14 @@ pub mod pallet {
 	/// it is optional, it is also possible to provide a custom implementation.
 	#[pallet::generate_deposit(pub (super) fn deposit_event)]
 	pub enum Event<T: Config> {
+		/// New Network Added
+		NetworkAdded {
+			network: Network,
+		},
+		/// New Network Removed
+		NetworkRemoved {
+			network: Network,
+		},
 		/// New session is started
 		NewSessionStarted {
 			index: SessionIndex,
@@ -329,7 +369,8 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn active_networks)]
 	/// Currently active networks
-	pub(super) type ActiveNetworks<T: Config> = StorageValue<_, Vec<Network>, ValueQuery>;
+	pub(super) type ActiveNetworks<T: Config> =
+		StorageValue<_, sp_std::collections::btree_set::BTreeSet<Network>, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn active_relayers)]
@@ -445,6 +486,23 @@ impl<T: Config> Pallet<T> {
 		<CurrentIndex<T>>::put(new_session_index);
 		T::SessionChangeNotifier::on_new_session(map);
 		Self::deposit_event(Event::NewSessionStarted { index: new_session_index })
+	}
+
+	pub fn do_add_new_network(network: Network) {
+		let mut active_networks = <ActiveNetworks<T>>::get();
+		if !active_networks.contains(&network) {
+			active_networks.insert(network);
+			<ActiveNetworks<T>>::put(&active_networks);
+			T::SessionChangeNotifier::set_new_networks(active_networks);
+		}
+	}
+
+	pub fn do_remove_network(network: Network) {
+		let mut active_networks = <ActiveNetworks<T>>::get();
+		if active_networks.remove(&network) {
+			<ActiveNetworks<T>>::put(&active_networks);
+			T::SessionChangeNotifier::set_new_networks(active_networks);
+		}
 	}
 
 	pub fn do_nominate(nominator: T::AccountId, candidate: T::AccountId) -> Result<(), Error<T>> {

--- a/pallets/thea/src/lib.rs
+++ b/pallets/thea/src/lib.rs
@@ -727,6 +727,7 @@ pub mod pallet {
 				network: network.saturated_into(),
 				beneficiary: beneficiary.clone(),
 				payload,
+				index: pending_withdrawals.len() as u32
 			};
 
 			if let Err(()) = pending_withdrawals.try_push(withdrawal) {

--- a/pallets/thea/src/lib.rs
+++ b/pallets/thea/src/lib.rs
@@ -365,11 +365,11 @@ pub mod pallet {
 		// 	remaining_weight
 		// }
 		//
-		// fn on_initialize(_n: BlockNumberFor<T>) -> Weight {
-		// 	<IngressMessages<T>>::put(Vec::<TheaPalletMessages>::new());
-		// 	// TODO: Benchmarking for Thea Pallet
-		// 	1000 as Weight
-		// }
+		fn on_initialize(_n: BlockNumberFor<T>) -> Weight {
+			<IngressMessages<T>>::put(Vec::<TheaPalletMessages>::new());
+			// TODO: Benchmarking for Thea Pallet
+			1000 as Weight
+		}
 	}
 
 	// Extrinsic for Thea Pallet are defined here

--- a/pallets/thea/src/lib.rs
+++ b/pallets/thea/src/lib.rs
@@ -271,8 +271,8 @@ pub mod pallet {
 		DepositApproved(u8, T::AccountId, u128, u128, sp_core::H256),
 		/// Deposit claimed event ( recipient, number of deposits claimed )
 		DepositClaimed(T::AccountId, u128, u128, sp_core::H256),
-		/// Withdrawal Queued ( beneficiary, assetId, amount )
-		WithdrawalQueued(T::AccountId, Vec<u8>, u128, u128, u32),
+		/// Withdrawal Queued ( beneficiary, assetId, amount, index )
+		WithdrawalQueued(T::AccountId, Vec<u8>, u128, u128, u32, u32),
 		/// Withdrawal Ready (Network id, Nonce )
 		WithdrawalReady(Network, u32),
 		/// Withdrawal Executed (Nonce, network, Tx hash )
@@ -752,6 +752,7 @@ pub mod pallet {
 					asset_id,
 					amount,
 					withdrawal_nonce,
+					(pending_withdrawals.len() - 1) as u32
 				));
 			}
 			<PendingWithdrawals<T>>::insert(network, pending_withdrawals);

--- a/pallets/thea/src/lib.rs
+++ b/pallets/thea/src/lib.rs
@@ -272,7 +272,7 @@ pub mod pallet {
 		/// Deposit claimed event ( recipient, number of deposits claimed )
 		DepositClaimed(T::AccountId, u128, u128, sp_core::H256),
 		/// Withdrawal Queued ( beneficiary, assetId, amount, index )
-		WithdrawalQueued(T::AccountId, Vec<u8>, u128, u128, u32, u32),
+		WithdrawalQueued(Network, T::AccountId, Vec<u8>, u128, u128, u32, u32),
 		/// Withdrawal Ready (Network id, Nonce )
 		WithdrawalReady(Network, u32),
 		/// Withdrawal Executed (Nonce, network, Tx hash )
@@ -747,6 +747,7 @@ pub mod pallet {
 				pending_withdrawals = BoundedVec::default();
 			} else {
 				Self::deposit_event(Event::<T>::WithdrawalQueued(
+					network,
 					user,
 					beneficiary,
 					asset_id,
@@ -851,7 +852,7 @@ pub mod pallet {
 			}
 			<DepositNonce<T>>::insert(
 				approved_deposit.network_id.saturated_into::<Network>(),
-				approved_deposit.deposit_nonce + 1,
+				approved_deposit.deposit_nonce,
 			);
 			Self::deposit_event(Event::<T>::DepositApproved(
 				approved_deposit.network_id,

--- a/pallets/thea/src/lib.rs
+++ b/pallets/thea/src/lib.rs
@@ -670,6 +670,12 @@ pub mod pallet {
 			Ok(())
 		}
 
+		/// Extrinsic to reset Thea Key Rotation
+		///
+		/// # Parameters
+		///
+		/// * `origin`: Any relayer
+		/// * `network`: Network id
 		#[pallet::weight(1000)]
 		pub fn thea_relayers_reset_rotation(
 			origin: OriginFor<T>,

--- a/pallets/thea/src/lib.rs
+++ b/pallets/thea/src/lib.rs
@@ -32,7 +32,6 @@ pub mod pallet {
 
 	use frame_support::{
 		dispatch::fmt::Debug,
-		log,
 		pallet_prelude::*,
 		traits::{Currency, ExistenceRequirement, ReservableCurrency},
 		PalletId,

--- a/pallets/thea/src/lib.rs
+++ b/pallets/thea/src/lib.rs
@@ -43,12 +43,10 @@ pub mod pallet {
 	};
 
 	use thea_primitives::{
-		thea_types::OnSessionChange,
-		BLSPublicKey, TheaPalletMessages,
 		normal_deposit::Deposit,
 		parachain_primitives::{ParachainAsset, ParachainDeposit, ParachainWithdraw},
-		AssetIdConverter, TokenType,
-		ApprovedWithdraw
+		thea_types::OnSessionChange,
+		ApprovedWithdraw, AssetIdConverter, BLSPublicKey, TheaPalletMessages, TokenType,
 	};
 	use thea_staking::SessionChanged;
 	use xcm::{
@@ -116,35 +114,20 @@ pub mod pallet {
 	/// Active Relayers BLS Keys for a given Network
 	#[pallet::storage]
 	#[pallet::getter(fn get_key_rotation_status)]
-	pub(super) type TheaKeyRotation<T: Config> = StorageMap<
-		_,
-		frame_support::Blake2_128Concat,
-		u8,
-		bool,
-		ValueQuery,
-	>;
+	pub(super) type TheaKeyRotation<T: Config> =
+		StorageMap<_, frame_support::Blake2_128Concat, u8, bool, ValueQuery>;
 
 	/// Active Relayers BLS Keys for a given Network
 	#[pallet::storage]
 	#[pallet::getter(fn get_relayers_key_vector)]
-	pub(super) type RelayersBLSKeyVector<T: Config> = StorageMap<
-		_,
-		frame_support::Blake2_128Concat,
-		u8,
-		Vec<BLSPublicKey>,
-		ValueQuery,
-	>;
+	pub(super) type RelayersBLSKeyVector<T: Config> =
+		StorageMap<_, frame_support::Blake2_128Concat, u8, Vec<BLSPublicKey>, ValueQuery>;
 
 	/// Active Relayers ECDSA Keys for a given Network
 	#[pallet::storage]
 	#[pallet::getter(fn get_auth_list)]
-	pub(super) type AuthorityListVector<T: Config> = StorageMap<
-		_,
-		frame_support::Blake2_128Concat,
-		u8,
-		Vec<T::AccountId>,
-		ValueQuery,
-	>;
+	pub(super) type AuthorityListVector<T: Config> =
+		StorageMap<_, frame_support::Blake2_128Concat, u8, Vec<T::AccountId>, ValueQuery>;
 
 	/// Queued Relayers BLS Keys for a given Network ( these are relayers who are waiting for
 	/// public key update ack from foreign chain to become active )
@@ -272,7 +255,7 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn get_ingress_messages)]
 	pub(super) type IngressMessages<T: Config> =
-	StorageValue<_, Vec<TheaPalletMessages>, ValueQuery>;
+		StorageValue<_, Vec<TheaPalletMessages>, ValueQuery>;
 
 	// Pallets use events to inform users when important changes are made.
 	// https://substrate.dev/docs/en/knowledgebase/runtime/events
@@ -283,7 +266,7 @@ pub mod pallet {
 		DepositApproved(u8, T::AccountId, u128, u128, sp_core::H256),
 		/// Deposit claimed event ( recipient, number of deposits claimed )
 		DepositClaimed(T::AccountId, u128, u128, sp_core::H256),
-		/// Withdrawal Queued ( beneficiary, assetId, amount, index )
+		/// Withdrawal Queued ( network, from, beneficiary, assetId, amount, nonce, index )
 		WithdrawalQueued(Network, T::AccountId, Vec<u8>, u128, u128, u32, u32),
 		/// Withdrawal Ready (Network id, Nonce )
 		WithdrawalReady(Network, u32),
@@ -335,61 +318,61 @@ pub mod pallet {
 		/// Bounded Vector Not Present
 		BoundedVectorNotPresent,
 		/// Thea Key Rotation is taking place
-		TheaKeyRotationInPlace
+		TheaKeyRotationInPlace,
 	}
 
 	// Hooks for Thea Pallet are defined here
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-		fn on_idle(_n: BlockNumberFor<T>, mut remaining_weight: Weight) -> Weight {
-			// TODO: Calculate proper weight for single claim call on on_idle
-			let single_claim_weight: Weight = 100_000_000;
-
-			if remaining_weight < single_claim_weight {
-				// We need enough weight for at least one claim process if not it's a no-op
-				return remaining_weight
-			}
-
-			let mut accounts = <AccountWithPendingDeposits<T>>::get();
-			if accounts.is_empty() {
-				return remaining_weight
-			}
-
-			while let Some(account) = accounts.pop_first() {
-				if let Some(mut pending_deposits) = <ApprovedDeposits<T>>::get(&account) {
-					// FIXME: This leads to an infinite loop if execute_deposit fails
-					while let Some(deposit) = pending_deposits.pop() {
-						if let Err(err) = Self::execute_deposit(deposit.clone(), &account) {
-							// Force push is fine as it was part of the bounded vec
-							pending_deposits.force_push(deposit.clone());
-							// We can't do much here other than to log an error.
-							log::error!(target:"runtime::thea::on_idle","Error while claiming deposit on idle: user: {:?}, Err: {:?}",account,err);
-						}
-						// reduce the remaining_weight
-						remaining_weight = remaining_weight.saturating_sub(single_claim_weight);
-						if remaining_weight.is_zero() {
-							break
-						}
-					}
-
-					if !pending_deposits.is_empty() {
-						<ApprovedDeposits<T>>::insert(&account, pending_deposits);
-						accounts.insert(account);
-					}
-				}
-			}
-			<AccountWithPendingDeposits<T>>::put(accounts);
-			remaining_weight
-		}
-
-		fn on_initialize(_n: BlockNumberFor<T>) -> Weight {
-			<IngressMessages<T>>::put(Vec::<TheaPalletMessages>::new());
-			// TODO: Benchmarking for Thea Pallet
-			1000 as Weight
-		}
+		// fn on_idle(_n: BlockNumberFor<T>, mut remaining_weight: Weight) -> Weight {
+		// 	// TODO: Calculate proper weight for single claim call on on_idle
+		// 	let single_claim_weight: Weight = 100_000_000;
+		//
+		// 	if remaining_weight < single_claim_weight {
+		// 		// We need enough weight for at least one claim process if not it's a no-op
+		// 		return remaining_weight
+		// 	}
+		//
+		// 	let mut accounts = <AccountWithPendingDeposits<T>>::get();
+		// 	if accounts.is_empty() {
+		// 		return remaining_weight
+		// 	}
+		//
+		// 	while let Some(account) = accounts.pop_first() {
+		// 		if let Some(mut pending_deposits) = <ApprovedDeposits<T>>::get(&account) {
+		// 			// FIXME: This leads to an infinite loop if execute_deposit fails
+		// 			while let Some(deposit) = pending_deposits.pop() {
+		// 				if let Err(err) = Self::execute_deposit(deposit.clone(), &account) {
+		// 					// Force push is fine as it was part of the bounded vec
+		// 					pending_deposits.force_push(deposit.clone());
+		// 					// We can't do much here other than to log an error.
+		// 					log::error!(target:"runtime::thea::on_idle","Error while claiming deposit on idle: user: {:?}, Err: {:?}",account,err);
+		// 				}
+		// 				// reduce the remaining_weight
+		// 				remaining_weight = remaining_weight.saturating_sub(single_claim_weight);
+		// 				if remaining_weight.is_zero() {
+		// 					break
+		// 				}
+		// 			}
+		//
+		// 			if !pending_deposits.is_empty() {
+		// 				<ApprovedDeposits<T>>::insert(&account, pending_deposits);
+		// 				accounts.insert(account);
+		// 			}
+		// 		}
+		// 	}
+		// 	<AccountWithPendingDeposits<T>>::put(accounts);
+		// 	remaining_weight
+		// }
+		//
+		// fn on_initialize(_n: BlockNumberFor<T>) -> Weight {
+		// 	<IngressMessages<T>>::put(Vec::<TheaPalletMessages>::new());
+		// 	// TODO: Benchmarking for Thea Pallet
+		// 	1000 as Weight
+		// }
 	}
 
-	// Extrinsics for Thea Pallet are defined here
+	// Extrinsic for Thea Pallet are defined here
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		///Approve Deposit
@@ -599,7 +582,7 @@ pub mod pallet {
 			network: Network,
 			public_key: [u8; 64],
 			bit_map: u128,
-			bls_signature: [u8; 96]
+			bls_signature: [u8; 96],
 		) -> DispatchResult {
 			let _relayer = ensure_signed(origin)?;
 			// Verify BLS Signature
@@ -648,7 +631,8 @@ pub mod pallet {
 			let _relayer = ensure_signed(origin)?;
 			// Fetch current active relayer set BLS Keys
 
-			let current_public_key = <QueuedQueuedTheaPublicKey<T>>::get(network).unwrap_or([0_u8; 64]);
+			let current_public_key =
+				<QueuedQueuedTheaPublicKey<T>>::get(network).unwrap_or([0_u8; 64]);
 			ensure!(public_key != current_public_key, Error::<T>::QueuedTheaPublicKeyNotFound);
 
 			let queued_queued_relayers =
@@ -692,14 +676,19 @@ pub mod pallet {
 			let _root = ensure_root(origin)?;
 			<AuthorityListVector<T>>::insert::<u8, Vec<T::AccountId>>(network, Default::default());
 			<RelayersBLSKeyVector<T>>::insert::<u8, Vec<BLSPublicKey>>(network, Default::default());
-			<QueuedAuthorityListVector<T>>::insert::<u8, Vec<T::AccountId>>(network, Default::default());
-			<QueuedRelayersBLSKeyVector<T>>::insert::<u8, Vec<BLSPublicKey>>(network, Default::default());
+			<QueuedAuthorityListVector<T>>::insert::<u8, Vec<T::AccountId>>(
+				network,
+				Default::default(),
+			);
+			<QueuedRelayersBLSKeyVector<T>>::insert::<u8, Vec<BLSPublicKey>>(
+				network,
+				Default::default(),
+			);
 			<TheaPublicKey<T>>::take(network);
 			<QueuedTheaPublicKey<T>>::take(network);
 			<QueuedQueuedTheaPublicKey<T>>::take(network);
 			<TheaSessionId<T>>::insert(network, 0);
 			Ok(())
-
 		}
 	}
 
@@ -720,7 +709,10 @@ pub mod pallet {
 			// TODO: This will be refactored when work on withdrawal so not fixing clippy suggestion
 			let (network, ..) = asset_handler::pallet::Pallet::<T>::get_thea_assets(asset_id);
 			ensure!(network != 0, Error::<T>::UnableFindNetworkForAssetId);
-			ensure!(Self::get_key_rotation_status(network) != true, Error::<T>::TheaKeyRotationInPlace);
+			ensure!(
+				Self::get_key_rotation_status(network) != true,
+				Error::<T>::TheaKeyRotationInPlace
+			);
 			let payload = Self::withdrawal_router(network, asset_id, amount, beneficiary.clone())?;
 			let withdrawal_nonce = <WithdrawalNonces<T>>::get(network);
 
@@ -762,13 +754,21 @@ pub mod pallet {
 				network: network.saturated_into(),
 				beneficiary: beneficiary.clone(),
 				payload,
-				index: pending_withdrawals.len() as u32
+				index: pending_withdrawals.len() as u32,
 			};
 
 			if let Err(()) = pending_withdrawals.try_push(withdrawal) {
 				// This should not fail because of is_full check above
 			}
-
+			Self::deposit_event(Event::<T>::WithdrawalQueued(
+				network,
+				user,
+				beneficiary,
+				asset_id,
+				amount,
+				withdrawal_nonce,
+				(pending_withdrawals.len() - 1) as u32,
+			));
 			if pending_withdrawals.is_full() | pay_for_remaining {
 				// If it is full then we move it to ready queue and update withdrawal nonce
 				let withdrawal_nonce = <WithdrawalNonces<T>>::get(network);
@@ -780,16 +780,6 @@ pub mod pallet {
 				<WithdrawalNonces<T>>::insert(network, withdrawal_nonce.saturating_add(1));
 				Self::deposit_event(Event::<T>::WithdrawalReady(network, withdrawal_nonce));
 				pending_withdrawals = BoundedVec::default();
-			} else {
-				Self::deposit_event(Event::<T>::WithdrawalQueued(
-					network,
-					user,
-					beneficiary,
-					asset_id,
-					amount,
-					withdrawal_nonce,
-					(pending_withdrawals.len() - 1) as u32
-				));
 			}
 			<PendingWithdrawals<T>>::insert(network, pending_withdrawals);
 			Ok(())

--- a/pallets/thea/src/lib.rs
+++ b/pallets/thea/src/lib.rs
@@ -563,6 +563,8 @@ pub mod pallet {
 				messages.push(TheaPalletMessages::TheaKeyRotationComplete)
 			});
 
+			<TheaKeyRotation<T>>::insert(network, false);
+
 			Ok(())
 		}
 

--- a/pallets/thea/src/lib.rs
+++ b/pallets/thea/src/lib.rs
@@ -711,10 +711,7 @@ pub mod pallet {
 			// TODO: This will be refactored when work on withdrawal so not fixing clippy suggestion
 			let (network, ..) = asset_handler::pallet::Pallet::<T>::get_thea_assets(asset_id);
 			ensure!(network != 0, Error::<T>::UnableFindNetworkForAssetId);
-			ensure!(
-				!Self::get_key_rotation_status(network),
-				Error::<T>::TheaKeyRotationInPlace
-			);
+			ensure!(!Self::get_key_rotation_status(network), Error::<T>::TheaKeyRotationInPlace);
 			let payload = Self::withdrawal_router(network, asset_id, amount, beneficiary.clone())?;
 			let withdrawal_nonce = <WithdrawalNonces<T>>::get(network);
 

--- a/pallets/thea/src/lib.rs
+++ b/pallets/thea/src/lib.rs
@@ -56,6 +56,7 @@ pub mod pallet {
 		prelude::{Fungible, X1},
 	};
 
+	use core::default::Default;
 	pub type Network = u8;
 
 	#[derive(Encode, Decode, Clone, Copy, Debug, MaxEncodedLen, TypeInfo)]
@@ -666,6 +667,24 @@ pub mod pallet {
 
 			// Add the new one to queued_queued
 			Ok(())
+		}
+
+		#[pallet::weight(1000)]
+		pub fn thea_relayers_reset_rotation(
+			origin: OriginFor<T>,
+			network: Network,
+		) -> DispatchResult {
+			let _root = ensure_root(origin)?;
+			<AuthorityListVector<T>>::insert::<u8, Vec<T::AccountId>>(network, Default::default());
+			<RelayersBLSKeyVector<T>>::insert::<u8, Vec<BLSPublicKey>>(network, Default::default());
+			<QueuedAuthorityListVector<T>>::insert::<u8, Vec<T::AccountId>>(network, Default::default());
+			<QueuedRelayersBLSKeyVector<T>>::insert::<u8, Vec<BLSPublicKey>>(network, Default::default());
+			<TheaPublicKey<T>>::take(network);
+			<QueuedTheaPublicKey<T>>::take(network);
+			<QueuedQueuedTheaPublicKey<T>>::take(network);
+			<TheaSessionId<T>>::insert(network, 0);
+			Ok(())
+
 		}
 	}
 

--- a/pallets/thea/src/lib.rs
+++ b/pallets/thea/src/lib.rs
@@ -675,7 +675,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			network: Network,
 		) -> DispatchResult {
-			let _root = ensure_root(origin)?;
+			ensure_root(origin)?;
 			<AuthorityListVector<T>>::insert::<u8, Vec<T::AccountId>>(network, Default::default());
 			<RelayersBLSKeyVector<T>>::insert::<u8, Vec<BLSPublicKey>>(network, Default::default());
 			<QueuedAuthorityListVector<T>>::insert::<u8, Vec<T::AccountId>>(
@@ -712,7 +712,7 @@ pub mod pallet {
 			let (network, ..) = asset_handler::pallet::Pallet::<T>::get_thea_assets(asset_id);
 			ensure!(network != 0, Error::<T>::UnableFindNetworkForAssetId);
 			ensure!(
-				Self::get_key_rotation_status(network) != true,
+				!Self::get_key_rotation_status(network),
 				Error::<T>::TheaKeyRotationInPlace
 			);
 			let payload = Self::withdrawal_router(network, asset_id, amount, beneficiary.clone())?;

--- a/pallets/thea/src/lib.rs
+++ b/pallets/thea/src/lib.rs
@@ -346,8 +346,8 @@ pub mod pallet {
 		// 					// Force push is fine as it was part of the bounded vec
 		// 					pending_deposits.force_push(deposit.clone());
 		// 					// We can't do much here other than to log an error.
-		// 					log::error!(target:"runtime::thea::on_idle","Error while claiming deposit on idle: user: {:?}, Err: {:?}",account,err);
-		// 				}
+		// 					log::error!(target:"runtime::thea::on_idle","Error while claiming deposit on idle: user:
+		// {:?}, Err: {:?}",account,err); 				}
 		// 				// reduce the remaining_weight
 		// 				remaining_weight = remaining_weight.saturating_sub(single_claim_weight);
 		// 				if remaining_weight.is_zero() {

--- a/pallets/thea/src/lib.rs
+++ b/pallets/thea/src/lib.rs
@@ -16,11 +16,12 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::unused_unit)]
 
-#[cfg(test)]
-mod mock;
-
-#[cfg(test)]
-mod tests;
+// TODO[#614]: Thea Pallet Tests
+// #[cfg(test)]
+// mod mock;
+//
+// #[cfg(test)]
+// mod tests;
 
 #[frame_support::pallet]
 pub mod pallet {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1308,7 +1308,7 @@ impl thea::pallet::Config for Runtime {
 
 //Install Staking Pallet
 parameter_types! {
-	pub const SessionLength: u32 = 300;
+	pub const SessionLength: u32 = 100;
 	pub const UnbondingDelay: u32 = 10;
 	pub const MaxUnlockChunks: u32 = 10;
 	pub const CandidateBond: Balance = 1_000_000_000_000;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1308,7 +1308,7 @@ impl thea::pallet::Config for Runtime {
 
 //Install Staking Pallet
 parameter_types! {
-	pub const SessionLength: u32 = 25;
+	pub const SessionLength: u32 = 300;
 	pub const UnbondingDelay: u32 = 10;
 	pub const MaxUnlockChunks: u32 = 10;
 	pub const CandidateBond: Balance = 1_000_000_000_000;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1308,7 +1308,7 @@ impl thea::pallet::Config for Runtime {
 
 //Install Staking Pallet
 parameter_types! {
-	pub const SessionLength: u32 = 10;
+	pub const SessionLength: u32 = 25;
 	pub const UnbondingDelay: u32 = 10;
 	pub const MaxUnlockChunks: u32 = 10;
 	pub const CandidateBond: Balance = 1_000_000_000_000;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1321,6 +1321,7 @@ impl thea_staking::Config for Runtime {
 	type StakingReserveIdentifier = StakingReserveIdentifier;
 	type StakingDataPruneDelay = StakingDataPruneDelay;
 	type SessionChangeNotifier = Thea;
+	type GovernanceOrigin = EnsureRootOrHalfOrderbookCouncil;
 }
 
 //Install Nomination Pool

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1308,7 +1308,7 @@ impl thea::pallet::Config for Runtime {
 
 //Install Staking Pallet
 parameter_types! {
-	pub const SessionLength: u32 = 100;
+	pub const SessionLength: u32 = 50;
 	pub const UnbondingDelay: u32 = 10;
 	pub const MaxUnlockChunks: u32 = 10;
 	pub const CandidateBond: Balance = 1_000_000_000_000;

--- a/thea-primitives/src/lib.rs
+++ b/thea-primitives/src/lib.rs
@@ -61,6 +61,16 @@ pub trait TheaExt {
 )]
 pub struct BLSPublicKey(pub [u8; 192]);
 
+#[derive(Debug, Encode, Decode, Clone, PartialEq, TypeInfo, MaxEncodedLen)]
+pub enum TheaPalletMessages {
+	// Begin Distributed key generation and the amount of offline stages
+	EcdsaReady(u16),
+	// Sign Q Public Key
+	SignQdPublicKey,
+	// Thea Key Rotation Complete
+	TheaKeyRotationComplete
+}
+
 pub fn return_set_bits(bit_map: u128) -> Vec<u8> {
 	let mut set_bits: Vec<u8> = vec![];
 	for i in 0..128 {

--- a/thea-primitives/src/lib.rs
+++ b/thea-primitives/src/lib.rs
@@ -91,6 +91,7 @@ pub struct ApprovedWithdraw {
 	pub network: u8,
 	pub beneficiary: Vec<u8>,
 	pub payload: Vec<u8>,
+	pub index: u32
 }
 
 impl ApprovedWithdraw {

--- a/thea-primitives/src/lib.rs
+++ b/thea-primitives/src/lib.rs
@@ -81,7 +81,8 @@ pub enum TheaPalletMessages {
 	// Sign Q Public Key
 	SignQdPublicKey,
 	// Thea Key Rotation Complete
-	TheaKeyRotationComplete
+	TheaKeyRotationComplete,
+}
 
 #[derive(Encode, Decode, Clone, Debug, TypeInfo, Eq, PartialEq)]
 pub struct ApprovedWithdraw {

--- a/thea-primitives/src/lib.rs
+++ b/thea-primitives/src/lib.rs
@@ -91,7 +91,7 @@ pub struct ApprovedWithdraw {
 	pub network: u8,
 	pub beneficiary: Vec<u8>,
 	pub payload: Vec<u8>,
-	pub index: u32
+	pub index: u32,
 }
 
 impl ApprovedWithdraw {


### PR DESCRIPTION
Relayers should use Queued Relayers of Thea Staking Pallet and Active Relayers of Thea pallet for operations. Thea pallet will generate an ingress message when the key updation is complete on foreign chain after which new relayers can start processing withdrawals.  Queued Relayers of Thea Staking Pallet is used to pre-generate Thea Public key and Offline Stages  for next set and update the on-chain state about it.