### PR TITLE
feat: era reward payout 

### DIFF
--- a/pallets/thea-staking/src/lib.rs
+++ b/pallets/thea-staking/src/lib.rs
@@ -66,7 +66,7 @@ pub trait SessionChanged {
 #[frame_support::pallet]
 pub mod pallet {
 	use crate::session::{Exposure, IndividualExposure, StakingLimits};
-	use frame_support::traits::{Currency, NamedReservableCurrency, ReservableCurrency};
+	use frame_support::traits::{Currency, NamedReservableCurrency};
 	use frame_system::pallet_prelude::*;
 	use polkadex_primitives::misbehavior::TheaMisbehavior;
 	use scale_info::prelude::string::String;
@@ -703,7 +703,7 @@ pub mod pallet {
 			let total_issuance = <pallet_balances::Pallet<T> as Currency<_>>::total_issuance();
 			let eras_total_stake = <TotalSessionStake<T>>::get(era);
 			let (era_payout, _rest) =
-				T::EraPayout::era_payout(eras_total_stake, total_issuance, session_length.into());
+				T::EraPayout::era_payout(eras_total_stake, total_issuance, session_length);
 			<EraRewardPayout<T>>::insert(era, era_payout);
 		}
 
@@ -742,7 +742,7 @@ pub mod pallet {
 			// panic!("Alice individual payout: {:?}", total_payout);
 			// Mint it to the Relayer
 			let individual_payout: u32 = individual_payout.unique_saturated_into();
-			<pallet_balances::Pallet<T> as Currency<_>>::deposit_into_existing(
+			let _ = <pallet_balances::Pallet<T> as Currency<_>>::deposit_into_existing(
 				&stash_account,
 				individual_payout.into(),
 			)?;
@@ -756,7 +756,7 @@ pub mod pallet {
 					let nominator_payout = nominator_part * relayer_payout;
 					let nominator_payout: u32 = nominator_payout.unique_saturated_into();
 					// Mint Rewards for Nominators
-					<pallet_balances::Pallet<T> as Currency<_>>::deposit_into_existing(
+					let _ = <pallet_balances::Pallet<T> as Currency<_>>::deposit_into_existing(
 						&nominator,
 						nominator_payout.into(),
 					)?;

--- a/pallets/thea-staking/src/lib.rs
+++ b/pallets/thea-staking/src/lib.rs
@@ -144,9 +144,6 @@ pub mod pallet {
 
 		// Era Payout for set of Relayers
 		type EraPayout: EraPayout<BalanceOf<Self>>;
-
-		/// Native Currency handler
-		type Currency: Currency<Self::AccountId> + ReservableCurrency<Self::AccountId>;
 	}
 
 	// Simple declaration of the `Pallet` type. It is placeholder we use to implement traits and

--- a/pallets/thea-staking/src/mock.rs
+++ b/pallets/thea-staking/src/mock.rs
@@ -97,7 +97,7 @@ impl pallet_balances::Config for Test {
 }
 
 parameter_types! {
-	pub const SessionLength: u64 = 10;
+	pub const SessionLength: u64 = 7000;
 	pub const UnbondingDelay: u32 = 10;
 	pub const MaxUnlockChunks: u32 = 10;
 	pub const CandidateBond: Balance = 1000_000_000_000;

--- a/pallets/thea-staking/src/mock.rs
+++ b/pallets/thea-staking/src/mock.rs
@@ -126,7 +126,6 @@ impl thea_staking::Config for Test {
 	type TreasuryPalletId = TreasuryPalletId;
 	type GovernanceOrigin = EnsureRoot<u64>;
 	type EraPayout = pallet_staking::ConvertCurve<RewardCurve>;
-	type Currency = Balances;
 }
 
 pub struct MockPallet(PhantomData<u32>);

--- a/pallets/thea-staking/src/tests.rs
+++ b/pallets/thea-staking/src/tests.rs
@@ -1,4 +1,9 @@
-use crate::{mock::*, session::{Exposure, IndividualExposure, StakingLimits, UnlockChunk}, ActiveNetworks, Candidates, CurrentIndex, Error, Hooks, Perbill, Stakers, Stakinglimits, EraRewardPayout};
+use crate::{
+	mock::*,
+	session::{Exposure, IndividualExposure, StakingLimits, UnlockChunk},
+	ActiveNetworks, Candidates, CurrentIndex, EraRewardPayout, Error, Hooks, Perbill, Stakers,
+	Stakinglimits,
+};
 use frame_support::{assert_noop, assert_ok, traits::fungible::Mutate};
 use std::collections::BTreeSet;
 use thea_primitives::BLSPublicKey;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1379,7 +1379,6 @@ impl thea_staking::Config for Runtime {
 	type TreasuryPalletId = TreasuryPalletId;
 	type GovernanceOrigin = EnsureRootOrHalfOrderbookCouncil;
 	type EraPayout = pallet_staking::ConvertCurve<TheaRewardCurve>;
-	type Currency = Balances;
 }
 
 //Install Nomination Pool


### PR DESCRIPTION
This PR fixes reward payout for Relayers and removes the currency trait and using pallet_balances hard-coupled within the `Thea-Staking` Pallet. 
