### PR TITLE
CI node artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on:
   pull_request: []
   push:
-    branches: [Develop, mainnet-release]
+    branches: [Develop, mainnet-release, ci-node-artifact]
 
 env:
   RUNNER_INSTANCE_TYPE: c5.4xlarge
@@ -102,10 +102,10 @@ jobs:
           name: code-coverage-report
           path: cobertura.xml
       - name: Zip compiled binaries
-        if: contains(github.ref, "Develop")
+        if: contains(github.ref, "ci-node-artifact")
         run: zip ./target/release/polkadex-node.zip ./target/release/polkadex-node
       - name: Upload zipped binaries as an artifact
-        if: contains(github.ref, "Develop")
+        if: contains(github.ref, "ci-node-artifact")
         uses: actions/upload-artifact@v3
         with:
           name: polkadex-node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on:
   pull_request: []
   push:
-    branches: [Develop, mainnet-release, ci-node-artifact]
+    branches: [Develop, mainnet-release]
 
 env:
   RUNNER_INSTANCE_TYPE: c5.4xlarge
@@ -102,11 +102,11 @@ jobs:
           name: code-coverage-report
           path: cobertura.xml
       - name: Zip compiled binaries
-        if: contains(github.ref, 'ci-node-artifact')
+        if: contains(github.ref, 'Develop')
         # Zipping is required since billing is based on the raw uploaded size.
         run: zip -r -j polkadex-node.zip ./target/release/polkadex-node
       - name: Upload zipped binaries as an artifact
-        if: contains(github.ref, 'ci-node-artifact')
+        if: contains(github.ref, 'Develop')
         uses: actions/upload-artifact@v3
         with:
           name: polkadex-node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on:
   pull_request: []
   push:
-    branches: [Develop, main-net-runtime, redux-ci-testing]
+    branches: [Develop, mainnet-release]
 
 env:
   RUNNER_INSTANCE_TYPE: c5.4xlarge
@@ -101,6 +101,16 @@ jobs:
         with:
           name: code-coverage-report
           path: cobertura.xml
+      - name: Zip compiled binaries
+        if: contains(github.ref, "Develop")
+        run: zip ./target/release/polkadex-node.zip ./target/release/polkadex-node
+      - name: Upload zipped binaries as an artifact
+        if: contains(github.ref, "Develop")
+        uses: actions/upload-artifact@v3
+        with:
+          name: polkadex-node
+          path: ./target/release/polkadex-node.zip
+          if-no-files-found: error
   stop-runner:
     name: Stop self-hosted EC2 runner
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,10 +102,10 @@ jobs:
           name: code-coverage-report
           path: cobertura.xml
       - name: Zip compiled binaries
-        if: contains(github.ref, "ci-node-artifact")
+        if: contains(github.ref, 'ci-node-artifact')
         run: zip ./target/release/polkadex-node.zip ./target/release/polkadex-node
       - name: Upload zipped binaries as an artifact
-        if: contains(github.ref, "ci-node-artifact")
+        if: contains(github.ref, 'ci-node-artifact')
         uses: actions/upload-artifact@v3
         with:
           name: polkadex-node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: polkadex-node
-          path: ./target/release/polkadex-node.zip
+          path: ./polkadex-node.zip
           if-no-files-found: error
   stop-runner:
     name: Stop self-hosted EC2 runner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,8 @@ jobs:
           path: cobertura.xml
       - name: Zip compiled binaries
         if: contains(github.ref, 'ci-node-artifact')
-        run: zip ./target/release/polkadex-node.zip ./target/release/polkadex-node
+        # Zipping is required since billing is based on the raw uploaded size.
+        run: zip -r -j polkadex-node.zip ./target/release/polkadex-node
       - name: Upload zipped binaries as an artifact
         if: contains(github.ref, 'ci-node-artifact')
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           cat /etc/issue 
           apt update
-          apt install -y clang lldb lld gcc
+          apt install -y clang lldb lld gcc zip
       - name: Install latest nightly with wasm target
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
In this PR in the CI added node compiled binary as an artifact to be fetched from other repositories for the testing purpose. This changes reduces e2e execution time on ~7 minutes (which is ~27%).

Related to PR [748](https://github.com/Polkadex-Substrate/orderbook/pull/748).
