### PR TITLE
fix runtime for rewards-api

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -189,7 +189,7 @@ std = [
     "pallet-asset-handler-runtime-api/std",
     "thea-staking/std",
     "pallet-nomination-pools/std",
-    "pallet-asset-handler-runtime-api/std",
+    "pallet-rewards-runtime-api/std",
     "thea/std",
     "pallet-amm/std",
     "router/std",


### PR DESCRIPTION
## Describe your changes
The runtime for node was not building standalone after merging this [pr](https://github.com/Polkadex-Substrate/Polkadex/pull/712) , the current pr fixes runtime build

