### PR TITLE
Add runtime build check to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
         run: cargo build --features runtime-benchmarks
       - name: Normal Build
         run: RUSTFLAGS="-D warnings" cargo build
+      - name: Runtime build
+        run: cargo build -p node-polkadex-runtime
       - name: Check Formatting
         run: cargo fmt --check
       - name: Check Clippy


### PR DESCRIPTION
CI could not detect regression when checking the full build, because of that - runtime crate should be checked separately. In this PR was added new step in the CI to test runtime build separately. Original report by @nuel77 is [here](https://polkadextechnical.slack.com/archives/C01ENLU0EBT/p1681823670101959).


