### PR TITLE
Reload Last snapshot state after Error

### DIFF
--- a/clients/orderbook/src/worker.rs
+++ b/clients/orderbook/src/worker.rs
@@ -625,12 +625,13 @@ where
 						// We need to revert everything after the last successful snapshot
 						// Clear the working state
 						self.memory_db.write().clear();
+						info!(target:"orderbook","Working state cleared.");
 						// We forget about everything else from cache.
 						self.known_messages.clear();
-						let latest_summary = self.runtime
-							.runtime_api()
-							.get_latest_snapshot(
-								&BlockId::Number(self.last_finalized_block))?;
+						info!(target:"orderbook","OB messages cache cleared.");
+						let latest_summary = self.runtime.runtime_api().get_latest_snapshot(
+							&BlockId::Number(self.last_finalized_block.saturated_into()),
+						)?;
 						self.load_snapshot(&latest_summary)?;
 						return Ok(())
 					},

--- a/clients/thea/src/connector/parachain.rs
+++ b/clients/thea/src/connector/parachain.rs
@@ -29,9 +29,7 @@ impl ForeignConnector for ParachainClient {
 
 	async fn read_events(&self, nonce: u64) -> Result<Option<Message>, Error> {
 		// Read thea messages from foreign chain
-		let storage_address = parachain::storage()
-			.thea_message_handler()
-			.outgoing_messages(nonce);
+		let storage_address = parachain::storage().thea_message_handler().outgoing_messages(nonce);
 		// TODO: Get last finalized block hash
 		let encoded_bytes =
 			self.api.storage().at_latest().await?.fetch(&storage_address).await?.encode();
@@ -47,7 +45,8 @@ impl ForeignConnector for ParachainClient {
 			Decode::decode(&mut &message.aggregate_signature.encode()[..])?,
 		);
 		info!(target:"thea", "Tx created: {:?}",call);
-		let tx_result = self.api
+		let tx_result = self
+			.api
 			.tx()
 			.create_unsigned(&call)?
 			.submit_and_watch()

--- a/clients/thea/src/gossip.rs
+++ b/clients/thea/src/gossip.rs
@@ -114,7 +114,7 @@ where
 			if self.validate_message(&thea_gossip_msg) {
 				trace!(target:"thea-gossip", "Validation successfully for message: {thea_gossip_msg:?}");
 				return ValidationResult::ProcessAndKeep(topic::<B>())
-			}else{
+			} else {
 				trace!(target:"thea-gossip", "Validation failed for message: {thea_gossip_msg:?}");
 			}
 		}

--- a/pallets/thea/src/lib.rs
+++ b/pallets/thea/src/lib.rs
@@ -28,7 +28,9 @@ use sp_std::prelude::*;
 
 pub use pallet::*;
 use polkadex_primitives::utils::return_set_bits;
-use thea_primitives::{types::Message, Network, ValidatorSet, GENESIS_AUTHORITY_SET_ID, NATIVE_NETWORK};
+use thea_primitives::{
+	types::Message, Network, ValidatorSet, GENESIS_AUTHORITY_SET_ID, NATIVE_NETWORK,
+};
 
 mod session;
 
@@ -135,7 +137,7 @@ pub mod pallet {
 		/// Wrong nonce provided
 		MessageNonce,
 		/// No validators for this network
-		NoValidatorsFound(Network)
+		NoValidatorsFound(Network),
 	}
 
 	#[pallet::validate_unsigned]
@@ -199,10 +201,10 @@ pub mod pallet {
 		pub fn send_thea_message(
 			origin: OriginFor<T>,
 			data: Vec<u8>,
-			network: Network
+			network: Network,
 		) -> DispatchResult {
 			ensure_root(origin)?;
-			Self::execute_withdrawals(network,data)?;
+			Self::execute_withdrawals(network, data)?;
 			Ok(())
 		}
 	}
@@ -365,7 +367,7 @@ impl<T: Config> Pallet<T> {
 }
 
 impl<T: Config> thea_primitives::TheaOutgoingExecutor for Pallet<T> {
-	fn execute_withdrawals(network: Network, data: Vec<u8>) ->  DispatchResult {
+	fn execute_withdrawals(network: Network, data: Vec<u8>) -> DispatchResult {
 		let auth_len = Self::authorities(network).len();
 		if auth_len == 0 {
 			return Err(Error::<T>::NoValidatorsFound(network).into())


### PR DESCRIPTION
Reloads the last successful snapshot state when off-chain workers encounter an error while handling `UserActions` from Orderbook.