### PR TITLE
Add State version

### DIFF
--- a/clients/orderbook/src/tests/gosssip.rs
+++ b/clients/orderbook/src/tests/gosssip.rs
@@ -142,6 +142,8 @@ fn create_ob_message_import_block(
 		stid: nonce,
 		action: UserActions::BlockImport(blk_num),
 		signature: Default::default(),
+		reset: false,
+		version: 0,
 	};
 	msg.signature = pair.sign_prehashed(&msg.sign_data());
 	return msg

--- a/clients/orderbook/src/tests/mod.rs
+++ b/clients/orderbook/src/tests/mod.rs
@@ -85,6 +85,7 @@ impl TestApi {
 				bitflags: vec![],
 				withdrawals: vec![],
 				aggregate_signature: None,
+				state_version: 0,
 			})
 			.clone()
 	}
@@ -159,6 +160,7 @@ impl TestApi {
 				bitflags: vec![],
 				withdrawals: vec![],
 				aggregate_signature: None,
+				state_version: 0,
 			})
 			.worker_nonce
 	}

--- a/clients/orderbook/src/tests/rpc.rs
+++ b/clients/orderbook/src/tests/rpc.rs
@@ -151,6 +151,8 @@ pub async fn test_orderbook_rpc() {
 		stid: 10,
 		action: UserActions::BlockImport(1),
 		signature: Default::default(),
+		reset: false,
+		version: 0,
 	};
 	message.signature = orderbook_operator.sign_prehashed(&message.sign_data());
 	// Generate one block

--- a/clients/orderbook/src/tests/sync.rs
+++ b/clients/orderbook/src/tests/sync.rs
@@ -79,6 +79,8 @@ pub async fn test_orderbook_snapshot() {
 		stid: 10,
 		action: UserActions::BlockImport(1),
 		signature: Default::default(),
+		reset: false,
+		version: 0,
 	};
 	message.signature = orderbook_operator.sign_prehashed(&message.sign_data());
 	testnet.peers[0]

--- a/pallets/ocex/src/tests.rs
+++ b/pallets/ocex/src/tests.rs
@@ -1563,6 +1563,7 @@ fn get_dummy_snapshot(
 		bitflags: vec![1, 2],
 		withdrawals,
 		aggregate_signature: None,
+		state_version: 0,
 	};
 	let (pair, _seed) = bls_primitives::Pair::generate();
 	snapshot.aggregate_signature = Some(pair.sign(&snapshot.sign_data()));

--- a/primitives/orderbook/src/lib.rs
+++ b/primitives/orderbook/src/lib.rs
@@ -155,7 +155,7 @@ pub struct SnapshotSummary<AccountId: Clone + Codec> {
 	pub bitflags: Vec<u128>,
 	pub withdrawals: Vec<Withdrawal<AccountId>>,
 	pub aggregate_signature: Option<bls_primitives::Signature>,
-	pub state_version: u16
+	pub state_version: u16,
 }
 
 impl<AccountId: Clone + Codec> Default for SnapshotSummary<AccountId> {

--- a/primitives/orderbook/src/lib.rs
+++ b/primitives/orderbook/src/lib.rs
@@ -155,6 +155,7 @@ pub struct SnapshotSummary<AccountId: Clone + Codec> {
 	pub bitflags: Vec<u128>,
 	pub withdrawals: Vec<Withdrawal<AccountId>>,
 	pub aggregate_signature: Option<bls_primitives::Signature>,
+	pub state_version: u16
 }
 
 impl<AccountId: Clone + Codec> Default for SnapshotSummary<AccountId> {
@@ -170,6 +171,7 @@ impl<AccountId: Clone + Codec> Default for SnapshotSummary<AccountId> {
 			bitflags: Vec::new(),
 			withdrawals: Vec::new(),
 			aggregate_signature: None,
+			state_version: 0,
 		}
 	}
 }

--- a/primitives/orderbook/src/types.rs
+++ b/primitives/orderbook/src/types.rs
@@ -150,6 +150,8 @@ pub struct ObMessage {
 	pub worker_nonce: u64,
 	pub action: UserActions,
 	pub signature: sp_core::ecdsa::Signature,
+	pub reset: bool,
+	pub version: u16
 }
 
 #[cfg(feature = "std")]
@@ -186,7 +188,6 @@ pub enum UserActions {
 	Trade(Vec<Trade>),
 	Withdraw(WithdrawalRequest),
 	BlockImport(u32),
-	Reset
 }
 
 #[derive(Clone, Debug, Decode, Encode, serde::Serialize, serde::Deserialize)]

--- a/primitives/orderbook/src/types.rs
+++ b/primitives/orderbook/src/types.rs
@@ -151,7 +151,7 @@ pub struct ObMessage {
 	pub action: UserActions,
 	pub signature: sp_core::ecdsa::Signature,
 	pub reset: bool,
-	pub version: u16
+	pub version: u16,
 }
 
 #[cfg(feature = "std")]
@@ -755,6 +755,8 @@ mod tests {
 			worker_nonce: 0,
 			action: UserActions::BlockImport(1),
 			signature: Default::default(),
+			reset: false,
+			version: 0,
 		};
 
 		println!("OBMessage: {:?}", serde_json::to_string(&msg).unwrap());

--- a/primitives/orderbook/src/types.rs
+++ b/primitives/orderbook/src/types.rs
@@ -186,6 +186,7 @@ pub enum UserActions {
 	Trade(Vec<Trade>),
 	Withdraw(WithdrawalRequest),
 	BlockImport(u32),
+	Reset
 }
 
 #[derive(Clone, Debug, Decode, Encode, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
## Describe your changes

The state version allows segregating messages into pre and post-recovery of the engine, it avoid the orderbook client from executing old messages after recovery
