### PR TITLE
Percent instead of saturated arithmetics

### DIFF
--- a/pallets/thea-message-handler/src/lib.rs
+++ b/pallets/thea-message-handler/src/lib.rs
@@ -32,7 +32,7 @@ use parity_scale_codec::Encode;
 use sp_runtime::{
 	traits::{BlockNumberProvider, Member},
 	transaction_validity::{InvalidTransaction, TransactionValidity, ValidTransaction},
-	RuntimeAppPublic, SaturatedConversion,
+	Percent, RuntimeAppPublic, SaturatedConversion,
 };
 use sp_std::prelude::*;
 use thea_primitives::{types::Message, Network, ValidatorSet};
@@ -264,7 +264,9 @@ impl<T: Config> Pallet<T> {
 		}
 		let authorities = <Authorities<T>>::get(payload.validator_set_id).to_vec();
 		// Check for super majority
-		let threshold = authorities.len().saturating_mul(2).saturating_div(3);
+		const MAJORITY: u8 = 67;
+		let p = Percent::from_percent(MAJORITY);
+		let threshold = p * authorities.len();
 
 		if signatures.len() < threshold {
 			log::error!(target:"thea","Threshold: {:?}, Signs len: {:?}",threshold, signatures.len());

--- a/pallets/thea-message-handler/src/test.rs
+++ b/pallets/thea-message-handler/src/test.rs
@@ -26,14 +26,6 @@ use parity_scale_codec::{Decode, Encode};
 use sp_core::{ByteArray, Pair};
 use sp_runtime::traits::BadOrigin;
 
-fn assert_last_event<T: crate::Config>(generic_event: <T as crate::Config>::RuntimeEvent) {
-	let events = frame_system::Pallet::<T>::events();
-	let system_event: <T as frame_system::Config>::RuntimeEvent = generic_event.into();
-	// compare to the last event record
-	let EventRecord { event, .. } = &events[events.len() - 1];
-	assert_eq!(event, &system_event);
-}
-
 #[test]
 fn test_insert_authorities_full() {
 	new_test_ext().execute_with(|| {


### PR DESCRIPTION
Use of `Percent` and constant majority value instead of saturated arithmetic.