### PR TITLE
[HOTFIX] Corrected the branch name in CI workflow event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on:
   pull_request: []
   push:
-    branches: [Develop, main-net-runtime]
+    branches: [Develop, mainnet-release]
 
 env:
   RUNNER_INSTANCE_TYPE: c5d.9xlarge


### PR DESCRIPTION
## Describe your changes
At some point "main" branch name was changed (to main-net-runtime), but branch in workflow events list was left without update, so now whenever new PR merged into mainnet-release branch - CI does not triggered, but it supposed to.

## Issue ticket number and link
#854

## Checklist before requesting a review
- [X] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] I removed all Clippy and Formatting Warnings. 
- [x] I added required Copyrights.
