### PR TITLE
Fixed CI by changing taplo installation method 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,9 @@ jobs:
           default: true
           components: rustfmt, clippy
       - name: Install .toml files linter
-        run: cargo install taplo-cli
+        run: |
+          curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-linux-x86_64.gz \
+          | gzip -d - | install -m 755 /dev/stdin /usr/local/bin/taplo
       - name: Checkout to the current branch
         uses: actions/checkout@v3
       - name: Cache Rust Dependencies


### PR DESCRIPTION
## Describe your changes
After compiler version update - on attempt of `taplo` installation with command `cargo install taplo-cli` we received multiple errors:
```
error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/taplo-common-0.4.1/src/schema/mod.rs:555:29
    |
555 | ...                   Arc::try_unwrap(schema).unwrap()
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&Value`, found `Value`
    |
note: return type inferred to be `&serde_json::Value` here
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/taplo-common-0.4.1/src/schema/mod.rs:507:13
    |
507 |             return;
    |             ^^^^^^
help: consider borrowing here
    |
555 |                             &Arc::try_unwrap(schema).unwrap()
    |                             +

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/taplo-common-0.4.1/src/schema/mod.rs:557:29
    |
557 | ...                   all_of.clone()
    |                       ^^^^^^^^^^^^^^ expected `&Value`, found `Value`
    |
note: return type inferred to be `&serde_json::Value` here
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/taplo-common-0.4.1/src/schema/mod.rs:507:13
    |
507 |             return;
    |             ^^^^^^
help: try removing the method call
    |
557 -                             all_of.clone()
557 +                             all_of
    |

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/taplo-common-0.4.1/src/schema/mod.rs:562:37
    |
562 |                 merged_all_of.merge(schema);
    |                               ----- ^^^^^^ expected `&Value`, found `Value`
    |                               |
    |                               arguments to this method are incorrect
    |
note: method defined here
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/json_value_merge-1.2.0/src/lib.rs:9:8
    |
9   |     fn merge(&mut self, new_value: &Value);
    |        ^^^^^
help: consider borrowing here
    |
562 |                 merged_all_of.merge(&schema);
    |                                     +

For more information about this error, try `rustc --explain E0308`.
error: could not compile `taplo-common` (lib) due to 3 previous errors
warning: build failed, waiting for other jobs to finish...
error: failed to compile `taplo-cli v0.8.1`, intermediate artifacts can be found at `/tmp/cargo-installuTB8rU`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
Error: Process completed with exit code 101.
```
To fix this issue - used alternative method of installation with already pre-compiled binary  ([link](https://taplo.tamasfe.dev/cli/installation/binary.html)).

## Issue ticket number and link
No issue

## Checklist before requesting a review
- [X] I have performed a self-review of my code.
- [X] If it is a core feature, I have added thorough tests.
- [X] I removed all Clippy and Formatting Warnings. 
- [X] I added required Copyrights.
