### PR TITLE
Fix Withdraw precision issue

### DIFF
--- a/pallets/ocex/src/settlement.rs
+++ b/pallets/ocex/src/settlement.rs
@@ -21,6 +21,7 @@
 use crate::{storage::OffchainState, Config, Pallet};
 use core::ops::Sub;
 use log::{error, info};
+use num_traits::FromPrimitive;
 use orderbook_primitives::constants::POLKADEX_MAINNET_SS58;
 use orderbook_primitives::ocex::TradingPairConfig;
 use orderbook_primitives::types::Order;
@@ -117,7 +118,7 @@ pub fn sub_balance(
 	if *account_balance < balance {
 		// If the deviation is smaller that system limit, then we can allow what's stored in the offchain balance
 		let deviation = balance.sub(&*account_balance);
-		if !deviation.round_dp_with_strategy(8, ToZero).is_zero() {
+		if !deviation.round_dp_with_strategy(8, ToZero).is_zero() && deviation > Decimal::from_f32(0.00000001).unwrap(){
 			log::error!(target:"ocex","Asset found but balance low for asset: {:?}, of account: {:?}",asset, account);
 			return Err("NotEnoughBalance");
 		} else {

--- a/pallets/ocex/src/settlement.rs
+++ b/pallets/ocex/src/settlement.rs
@@ -118,7 +118,7 @@ pub fn sub_balance(
 	if *account_balance < balance {
 		// If the deviation is smaller that system limit, then we can allow what's stored in the offchain balance
 		let deviation = balance.sub(&*account_balance);
-		if !deviation.round_dp_with_strategy(8, ToZero).is_zero() && deviation > Decimal::from_f32(0.00000001).unwrap(){
+		if !deviation.round_dp_with_strategy(8, ToZero).is_zero() && deviation > Decimal::from_f32(0.000000011).unwrap(){
 			log::error!(target:"ocex","Asset found but balance low for asset: {:?}, of account: {:?}",asset, account);
 			return Err("NotEnoughBalance");
 		} else {

--- a/pallets/ocex/src/settlement.rs
+++ b/pallets/ocex/src/settlement.rs
@@ -103,7 +103,7 @@ pub fn sub_balance(
 	account: &AccountId,
 	asset: AssetId,
 	mut balance: Decimal,
-	is_withdrawal: bool
+	is_withdrawal: bool,
 ) -> Result<Decimal, &'static str> {
 	log::info!(target:"ocex", "subtracting {:?} asset {:?} from account {:?}", balance.to_f64().unwrap(), asset.to_string(), account);
 	let mut balances: BTreeMap<AssetId, Decimal> = match state.get(&account.to_raw_vec())? {
@@ -120,7 +120,7 @@ pub fn sub_balance(
 			let deviation = balance.sub(&*account_balance);
 			log::warn!(target:"ocex","[withdrawal] balance deviation of {:?} for asset: {:?}, of account: {:?}: Withdrawing available balance",deviation,asset.to_string(), account.to_ss58check_with_version(Ss58AddressFormat::from(POLKADEX_MAINNET_SS58)));
 			balance = *account_balance;
-		}else{
+		} else {
 			log::error!(target:"ocex","Asset found but balance low for asset: {:?}, of account: {:?}",asset, account);
 			return Err("NotEnoughBalance");
 		}

--- a/pallets/ocex/src/tests.rs
+++ b/pallets/ocex/src/tests.rs
@@ -252,7 +252,7 @@ fn test_two_assets() {
 		let asset456 = AssetId::Asset(456);
 		let amount456 = Decimal::from_str("10.0").unwrap();
 		// works
-		sub_balance(&mut state, &account_id, asset1, Decimal::from_str("0.01").unwrap().into())
+		sub_balance(&mut state, &account_id, asset1, Decimal::from_str("0.01").unwrap().into(), false)
 			.unwrap();
 		add_balance(&mut state, &coinalpha, asset123, amount123.into()).unwrap();
 		add_balance(&mut state, &coinalpha, asset456, amount456.into()).unwrap();
@@ -262,9 +262,9 @@ fn test_two_assets() {
 		let mut root = crate::storage::load_trie_root();
 		let mut trie_state = crate::storage::State;
 		let mut state = OffchainState::load(&mut trie_state, &mut root);
-		sub_balance(&mut state, &account_id, asset1, Decimal::from_str("0.01").unwrap().into())
+		sub_balance(&mut state, &account_id, asset1, Decimal::from_str("0.01").unwrap().into(), false)
 			.unwrap();
-		sub_balance(&mut state, &account_id, asset1, Decimal::from_str("0.01").unwrap().into())
+		sub_balance(&mut state, &account_id, asset1, Decimal::from_str("0.01").unwrap().into(), false)
 			.unwrap();
 	});
 }
@@ -282,7 +282,7 @@ fn test_sub_balance_new_account() {
 		let mut root = crate::storage::load_trie_root();
 		let mut trie_state = crate::storage::State;
 		let mut state = OffchainState::load(&mut trie_state, &mut root);
-		let result = sub_balance(&mut state, &account_id, asset_id, amount.into());
+		let result = sub_balance(&mut state, &account_id, asset_id, amount.into(), false);
 		match result {
 			Ok(_) => assert!(false),
 			Err(e) => assert_eq!(e, "Account not found in trie"),
@@ -316,7 +316,7 @@ fn test_sub_balance_existing_account_with_balance() {
 
 		//sub balance
 		let amount2 = 2000000;
-		let result = sub_balance(&mut state, &account_id, asset_id, amount2.into()).unwrap();
+		let result = sub_balance(&mut state, &account_id, asset_id, amount2.into(), false).unwrap();
 		assert_eq!(result, amount2.into());
 		let encoded = state.get(&account_id.to_raw_vec()).unwrap().unwrap();
 		let account_info: BTreeMap<AssetId, Decimal> = BTreeMap::decode(&mut &encoded[..]).unwrap();
@@ -324,7 +324,7 @@ fn test_sub_balance_existing_account_with_balance() {
 
 		//sub balance till 0
 		let amount3 = amount - amount2;
-		let result = sub_balance(&mut state, &account_id, asset_id, amount3.into()).unwrap();
+		let result = sub_balance(&mut state, &account_id, asset_id, amount3.into(), false).unwrap();
 		assert_eq!(result, amount3.into());
 		let encoded = state.get(&account_id.to_raw_vec()).unwrap().unwrap();
 		let account_info: BTreeMap<AssetId, Decimal> = BTreeMap::decode(&mut &encoded[..]).unwrap();
@@ -417,7 +417,7 @@ fn test_balance_update_depost_first_then_trade() {
 		//sub balance till 0
 		let amount3 = Decimal::from_f64_retain(2.0).unwrap();
 		let result =
-			sub_balance(&mut state, &account_id, AssetId::Polkadex, amount3.into()).unwrap();
+			sub_balance(&mut state, &account_id, AssetId::Polkadex, amount3.into(), false).unwrap();
 		assert_eq!(result, amount3);
 	});
 }
@@ -443,7 +443,7 @@ fn test_sub_more_than_available_balance_from_existing_account_with_balance() {
 
 		//sub balance
 		let amount2 = 4000000;
-		let result = sub_balance(&mut state, &account_id, asset_id, amount2.into());
+		let result = sub_balance(&mut state, &account_id, asset_id, amount2.into(), false);
 		match result {
 			Ok(_) => assert!(false),
 			Err(e) => assert_eq!(e, "NotEnoughBalance"),

--- a/pallets/ocex/src/tests.rs
+++ b/pallets/ocex/src/tests.rs
@@ -252,8 +252,14 @@ fn test_two_assets() {
 		let asset456 = AssetId::Asset(456);
 		let amount456 = Decimal::from_str("10.0").unwrap();
 		// works
-		sub_balance(&mut state, &account_id, asset1, Decimal::from_str("0.01").unwrap().into(), false)
-			.unwrap();
+		sub_balance(
+			&mut state,
+			&account_id,
+			asset1,
+			Decimal::from_str("0.01").unwrap().into(),
+			false,
+		)
+		.unwrap();
 		add_balance(&mut state, &coinalpha, asset123, amount123.into()).unwrap();
 		add_balance(&mut state, &coinalpha, asset456, amount456.into()).unwrap();
 		let root = state.commit().unwrap();
@@ -262,10 +268,22 @@ fn test_two_assets() {
 		let mut root = crate::storage::load_trie_root();
 		let mut trie_state = crate::storage::State;
 		let mut state = OffchainState::load(&mut trie_state, &mut root);
-		sub_balance(&mut state, &account_id, asset1, Decimal::from_str("0.01").unwrap().into(), false)
-			.unwrap();
-		sub_balance(&mut state, &account_id, asset1, Decimal::from_str("0.01").unwrap().into(), false)
-			.unwrap();
+		sub_balance(
+			&mut state,
+			&account_id,
+			asset1,
+			Decimal::from_str("0.01").unwrap().into(),
+			false,
+		)
+		.unwrap();
+		sub_balance(
+			&mut state,
+			&account_id,
+			asset1,
+			Decimal::from_str("0.01").unwrap().into(),
+			false,
+		)
+		.unwrap();
 	});
 }
 

--- a/pallets/ocex/src/validator.rs
+++ b/pallets/ocex/src/validator.rs
@@ -473,7 +473,7 @@ impl<T: Config> Pallet<T> {
 									.map_err(|_| "account id decode error")?,
 								market.quote_asset,
 								withdrawing_quote,
-								false
+								false,
 							)?;
 
 							// Sub Base
@@ -483,7 +483,7 @@ impl<T: Config> Pallet<T> {
 									.map_err(|_| "account id decode error")?,
 								market.base_asset,
 								withdrawing_base,
-								false
+								false,
 							)?;
 
 							// Egress message is verified
@@ -563,7 +563,7 @@ impl<T: Config> Pallet<T> {
 							.map_err(|_| "account id decode error")?,
 						market.base_asset,
 						base_balance,
-						false
+						false,
 					)?;
 
 					sub_balance(
@@ -572,7 +572,7 @@ impl<T: Config> Pallet<T> {
 							.map_err(|_| "account id decode error")?,
 						market.quote_asset,
 						quote_balance,
-						false
+						false,
 					)?;
 
 					verified_egress_messages.push(EgressMessages::PoolForceClosed(
@@ -621,7 +621,7 @@ impl<T: Config> Pallet<T> {
 									.map_err(|_| "account id decode error")?,
 								asset,
 								balance,
-								true
+								true,
 							)?;
 						}
 						verified_egress_messages.push(egress_msg.clone());
@@ -692,7 +692,7 @@ impl<T: Config> Pallet<T> {
 				.map_err(|_| "account id decode error")?,
 			request.asset(),
 			amount,
-			true
+			true,
 		)?;
 		let mut withdrawal = request.convert(stid).map_err(|_| "Withdrawal conversion error")?;
 		withdrawal.amount = actual_deducted; // The actual deducted balance

--- a/pallets/ocex/src/validator.rs
+++ b/pallets/ocex/src/validator.rs
@@ -473,6 +473,7 @@ impl<T: Config> Pallet<T> {
 									.map_err(|_| "account id decode error")?,
 								market.quote_asset,
 								withdrawing_quote,
+								false
 							)?;
 
 							// Sub Base
@@ -482,6 +483,7 @@ impl<T: Config> Pallet<T> {
 									.map_err(|_| "account id decode error")?,
 								market.base_asset,
 								withdrawing_base,
+								false
 							)?;
 
 							// Egress message is verified
@@ -561,6 +563,7 @@ impl<T: Config> Pallet<T> {
 							.map_err(|_| "account id decode error")?,
 						market.base_asset,
 						base_balance,
+						false
 					)?;
 
 					sub_balance(
@@ -569,6 +572,7 @@ impl<T: Config> Pallet<T> {
 							.map_err(|_| "account id decode error")?,
 						market.quote_asset,
 						quote_balance,
+						false
 					)?;
 
 					verified_egress_messages.push(EgressMessages::PoolForceClosed(
@@ -617,6 +621,7 @@ impl<T: Config> Pallet<T> {
 									.map_err(|_| "account id decode error")?,
 								asset,
 								balance,
+								true
 							)?;
 						}
 						verified_egress_messages.push(egress_msg.clone());
@@ -687,6 +692,7 @@ impl<T: Config> Pallet<T> {
 				.map_err(|_| "account id decode error")?,
 			request.asset(),
 			amount,
+			true
 		)?;
 		let mut withdrawal = request.convert(stid).map_err(|_| "Withdrawal conversion error")?;
 		withdrawal.amount = actual_deducted; // The actual deducted balance

--- a/pallets/ocex/src/validator.rs
+++ b/pallets/ocex/src/validator.rs
@@ -689,7 +689,7 @@ impl<T: Config> Pallet<T> {
 			amount,
 		)?;
 		let mut withdrawal = request.convert(stid).map_err(|_| "Withdrawal conversion error")?;
-		withdrawal.amount = actual_deducted; // The acutal deducted balance
+		withdrawal.amount = actual_deducted; // The actual deducted balance
 		Ok(withdrawal)
 	}
 

--- a/runtimes/mainnet/src/lib.rs
+++ b/runtimes/mainnet/src/lib.rs
@@ -122,7 +122,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 343,
+	spec_version: 344,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtimes/mainnet/src/lib.rs
+++ b/runtimes/mainnet/src/lib.rs
@@ -122,7 +122,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 345,
+	spec_version: 346,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtimes/mainnet/src/lib.rs
+++ b/runtimes/mainnet/src/lib.rs
@@ -122,7 +122,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 344,
+	spec_version: 345,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
## Describe your changes
Snapshot progress stalls due to precision loss in balance between engine and off chain state. This PR modifies the logic to withdraw the whole amount if amount requested is greater than available balance instead of throwing errors.
