### PR TITLE
Add extension sig support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6034,6 +6034,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "frame-support",
+ "hex",
  "log",
  "parity-scale-codec",
  "polkadex-primitives",

--- a/primitives/orderbook/Cargo.toml
+++ b/primitives/orderbook/Cargo.toml
@@ -25,7 +25,7 @@ anyhow = { version = "1.0.69", default-features = false }
 rust_decimal = { git = "https://github.com/Polkadex-Substrate/rust-decimal.git", branch = "master", features = [
   "scale-codec",
 ], default-features = false }
-
+hex = { workspace = true }
 
 [dev-dependencies]
 serde_json = "1.0.94"

--- a/primitives/orderbook/Cargo.toml
+++ b/primitives/orderbook/Cargo.toml
@@ -20,6 +20,7 @@ rand = { version = "0.8.5", optional = true }
 serde = { workspace = true, default-features = false }
 serde_with = { version = "3.6.1", features = ["json", "macros"], default-features = false }
 log = { workspace = true, default-features = false }
+serde_json = { workspace = true }
 anyhow = { version = "1.0.69", default-features = false }
 rust_decimal = { git = "https://github.com/Polkadex-Substrate/rust-decimal.git", branch = "master", features = [
   "scale-codec",

--- a/primitives/orderbook/src/constants.rs
+++ b/primitives/orderbook/src/constants.rs
@@ -35,6 +35,8 @@ pub const MAX_PRICE: Balance = 10000000 * UNIT_BALANCE;
 
 pub const FEE_POT_PALLET_ID: PalletId = PalletId(*b"ocexfees");
 
+pub const EXT_WRAP_PREFIX: &str = "<Bytes>";
+pub const EXT_WRAP_POSTFIX: &str = "</Bytes>";
 #[cfg(test)]
 mod test {
 	use crate::constants::{MAX_PRICE, MAX_QTY, POLKADEX_MAINNET_SS58};

--- a/primitives/orderbook/src/traits.rs
+++ b/primitives/orderbook/src/traits.rs
@@ -111,3 +111,7 @@ impl<AccountId> LiquidityMiningCrowdSourcePallet<AccountId> for () {
 
 	fn stop_accepting_lmp_withdrawals(_epoch: u16) {}
 }
+
+pub trait VerifyExtensionSignature<AccountId> {
+	fn verify_extension_signature(&self, payload: &str, account_id: &AccountId) -> bool;
+}

--- a/primitives/orderbook/src/types.rs
+++ b/primitives/orderbook/src/types.rs
@@ -91,9 +91,8 @@ pub struct Trade {
 
 impl VerifyExtensionSignature<AccountId> for MultiSignature {
 	fn verify_extension_signature(&self, payload: &str, account: &AccountId) -> bool {
-		const PREFIX: &str = "<Bytes>";
-		const POSTFIX: &str = "</Bytes>";
-		let wrapped_payload = PREFIX.to_string() + payload + POSTFIX;
+		let wrapped_payload = crate::constants::EXT_WRAP_PREFIX.to_string()
+			+ payload + crate::constants::EXT_WRAP_POSTFIX;
 		return self.verify(wrapped_payload.as_bytes(), account);
 	}
 }

--- a/primitives/orderbook/src/types.rs
+++ b/primitives/orderbook/src/types.rs
@@ -91,7 +91,9 @@ pub struct Trade {
 
 impl VerifyExtensionSignature<AccountId> for MultiSignature {
 	fn verify_extension_signature(&self, payload: &str, account: &AccountId) -> bool {
-		let wrapped_payload = format!("<Bytes>{}</Bytes>", payload);
+		const PREFIX: &str = "<Bytes>";
+		const POSTFIX: &str = "</Bytes>";
+		let wrapped_payload = PREFIX.to_string() + payload + POSTFIX;
 		return self.verify(wrapped_payload.as_bytes(), account);
 	}
 }

--- a/primitives/orderbook/src/types.rs
+++ b/primitives/orderbook/src/types.rs
@@ -1054,10 +1054,11 @@ mod tests {
 
 	#[test]
 	pub fn verify_signature_from_extension() {
+		// the string signed by polkadot-js api extension using signRaw
 		let payload = "hello world!";
 		let account =
 			AccountId::from_str("5FYr5g1maSsAAw6w98xdAytZ6MEQ8sNPgp3PNLgy9o79kMug").unwrap();
-		// raw signature from polkadot.js extension signRaw
+		// raw signature from polkadot-js api signRaw
 		let raw_signature = "36751864552cb500ef323ad1b4bd559ade88cff9b922bfdd0b1c18ace7429f57eacc2421dc3ea38a9c434593461fcae0ffa751280e25fedb48e406e42e0f6b82";
 		//convert raw signature to sr25519 signature
 		let sig = hex::decode(raw_signature).unwrap();

--- a/primitives/orderbook/src/types.rs
+++ b/primitives/orderbook/src/types.rs
@@ -1056,6 +1056,7 @@ mod tests {
 		let payload = "hello world!";
 		let account =
 			AccountId::from_str("5FYr5g1maSsAAw6w98xdAytZ6MEQ8sNPgp3PNLgy9o79kMug").unwrap();
+		// raw signature from polkadot.js extension signRaw
 		let raw_signature = "36751864552cb500ef323ad1b4bd559ade88cff9b922bfdd0b1c18ace7429f57eacc2421dc3ea38a9c434593461fcae0ffa751280e25fedb48e406e42e0f6b82";
 		//convert raw signature to sr25519 signature
 		let sig = hex::decode(raw_signature).unwrap();

--- a/primitives/orderbook/src/types.rs
+++ b/primitives/orderbook/src/types.rs
@@ -667,6 +667,7 @@ impl Order {
 				return true;
 			}
 		}
+		log::error!(target:"orderbook","orderbook extension signature check failed");
 		false
 	}
 


### PR DESCRIPTION
## Describe your changes
 - add support for verifying sr25519 signatures from pokadot.js extension called using signRaw. Enabling orders places via wallets (funding accounts) to be verified directly.
 - `RegisterMainAccount` extrinsic can be deprecated once support added fully to offchain worker and orderbook, as deposit extrinsic can directly register the funding account for new users, enabling users to start trading with one click.
