### PR TITLE
Make the incoming comparison using set instead of vec

### DIFF
--- a/pallets/thea/src/lib.rs
+++ b/pallets/thea/src/lib.rs
@@ -37,12 +37,12 @@ use sp_runtime::{
 	transaction_validity::{InvalidTransaction, TransactionValidity, ValidTransaction},
 	RuntimeAppPublic, SaturatedConversion,
 };
+use sp_std::collections::btree_set::BTreeSet;
 use sp_std::prelude::*;
 use thea_primitives::{
 	types::{Message, NetworkType, PayloadType},
 	Network, ValidatorSet, GENESIS_AUTHORITY_SET_ID,
 };
-use sp_std::collections::btree_set::BTreeSet;
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;

--- a/pallets/thea/src/lib.rs
+++ b/pallets/thea/src/lib.rs
@@ -42,6 +42,7 @@ use thea_primitives::{
 	types::{Message, NetworkType, PayloadType},
 	Network, ValidatorSet, GENESIS_AUTHORITY_SET_ID,
 };
+use sp_std::collections::btree_set::BTreeSet;
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
@@ -102,7 +103,6 @@ pub mod pallet {
 	};
 	use frame_system::offchain::SendTransactionTypes;
 	use polkadex_primitives::Balance;
-	use sp_std::collections::btree_set::BTreeSet;
 	use thea_primitives::{
 		types::{IncomingMessage, Message, MisbehaviourReport, SignedMessage, THEA_HOLD_REASON},
 		TheaIncomingExecutor, TheaOutgoingExecutor,
@@ -770,7 +770,8 @@ impl<T: Config> Pallet<T> {
 		// that is, the incoming set is has different session keys from outgoing set.
 		// This last message should be signed by the outgoing set
 		// Similar to how Grandpa's session change works.
-		if incoming != queued {
+		let incoming_set = BTreeSet::from_iter(incoming.to_vec());
+		if incoming_set != BTreeSet::from_iter(queued.to_vec()) {
 			let uncompressed_keys: Vec<[u8; 20]> = vec![];
 			// TODO: Uncomment the following when parsing is fixed for ethereum keys.
 			// for public_key in queued.clone().into_iter() {
@@ -844,7 +845,7 @@ impl<T: Config> Pallet<T> {
 			}
 			<NextAuthorities<T>>::put(queued);
 		}
-		if incoming != outgoing {
+		if incoming_set != BTreeSet::from_iter(outgoing.to_vec()) {
 			// This will happen when new era starts, or end of the last epoch
 			<Authorities<T>>::insert(new_id, incoming);
 			<ValidatorSetId<T>>::put(new_id);

--- a/pallets/thea/src/validation.rs
+++ b/pallets/thea/src/validation.rs
@@ -81,6 +81,7 @@ impl<T: Config> Pallet<T> {
 				None => continue,
 				Some(msg) => msg,
 			};
+
 			let msg_hash = sp_io::hashing::sha2_256(message.encode().as_slice());
 			// Note: this is a double hash signing
 			let signature =


### PR DESCRIPTION
## Describe your changes
The current set comparison is not working as expected. It is generating `ValidatorSetRotated` events before `ScheduleRotateValidators`, breaking the Thea session change.

## Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I removed all Clippy and Formatting Warnings. 
- [ ] I added required Copyrights.
