### PR TITLE
Gj/fix ob initial sync

### DIFF
--- a/pallets/ocex/src/validator.rs
+++ b/pallets/ocex/src/validator.rs
@@ -658,7 +658,9 @@ impl<T: Config> Pallet<T> {
 						return Err("Invalid egress message for withdraw trading fees");
 					}
 				},
-				IngressMessages::NewLMPEpoch(epoch) => Self::start_new_lmp_epoch(state, epoch)?,
+				IngressMessages::NewLMPEpoch(_epoch) => {
+					// Self::start_new_lmp_epoch(state, epoch)?
+				},
 				_ => {},
 			}
 		}

--- a/pallets/ocex/src/validator.rs
+++ b/pallets/ocex/src/validator.rs
@@ -668,6 +668,7 @@ impl<T: Config> Pallet<T> {
 		Ok(verified_egress_messages)
 	}
 
+	#[allow(dead_code)]
 	/// Reset the offchain state's LMP index and set the epoch
 	fn start_new_lmp_epoch(state: &mut OffchainState, epoch: u16) -> Result<(), &'static str> {
 		let mut config = if epoch > 1 {

--- a/runtimes/mainnet/src/lib.rs
+++ b/runtimes/mainnet/src/lib.rs
@@ -122,7 +122,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 369,
+	spec_version: 370,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
## Describe your changes

Working state keep track of LMP epochs causing checkpoint based initial sync to not work.
This PR removes LMP epoch from working state.

